### PR TITLE
feat: add auth routing proxy

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -12,7 +12,7 @@ def health():
 @app.route('/api/users/<path:path>', methods=['GET', 'POST', 'PUT', 'DELETE'])
 def proxy_users(path):
     """Proxy vers le service utilisateur"""
-    user_service_url = f"http://localhost:5001/{path}"
+    user_service_url = "http://localhost:5001/{}".format(path)
     try:
         response = requests.request(
             method=request.method,
@@ -26,10 +26,27 @@ def proxy_users(path):
         return jsonify({"error": "User service unavailable"}), 503
 
 
+@app.route('/api/auth/<path:path>', methods=['GET', 'POST', 'PUT', 'DELETE'])
+def proxy_auth(path):
+    """Proxy vers le service d'authentification"""
+    auth_service_url = "http://localhost:5002/{}".format(path)
+    try:
+        response = requests.request(
+            method=request.method,
+            url=auth_service_url,
+            headers=request.headers,
+            data=request.get_data(),
+            params=request.args
+        )
+        return response.content, response.status_code
+    except requests.exceptions.RequestException:
+        return jsonify({"error": "Auth service unavailable"}), 503
+
+
 @app.route('/api/events/<path:path>', methods=['GET', 'POST', 'PUT', 'DELETE'])
 def proxy_events(path):
     """Proxy vers le service événements"""
-    event_service_url = f"http://localhost:5003/{path}"
+    event_service_url = "http://localhost:5003/{}".format(path)
     try:
         response = requests.request(
             method=request.method,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,9 @@
+import os
+import sys
 import pytest
-from src.main import app
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from src.main import app  # noqa: E402
 
 
 @pytest.fixture
@@ -22,7 +26,14 @@ def test_app_runs(client):
     # Test d'une route qui n'existe pas
     response = client.get('/nonexistent')
     assert response.status_code == 404
-    
+
     # Test que l'app répond bien
     response = client.get('/health')
     assert response.status_code == 200
+
+
+def test_auth_service_unavailable(client):
+    """Test que le proxy auth renvoie une erreur si le service est indispo."""
+    response = client.post('/api/auth/login')
+    assert response.status_code == 503
+    assert response.json['error'] == 'Auth service unavailable'


### PR DESCRIPTION
## Summary
- add authentication proxy routing
- cover auth service errors with tests

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b47fc6e58833286325cd2f8229e02