### PR TITLE
Allow OPTIONS requests without JWT

### DIFF
--- a/src/middleware/jwt.py
+++ b/src/middleware/jwt.py
@@ -7,6 +7,8 @@ import jwt
 def require_jwt(fn):
     @wraps(fn)
     def wrapper(*args, **kwargs):
+        if request.method == "OPTIONS":
+            return fn(*args, **kwargs)
         auth_header = request.headers.get("Authorization", "")
         if not auth_header.startswith("Bearer "):
             return jsonify({"error": "Unauthorized"}), 401

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -43,6 +43,11 @@ def test_users_requires_jwt(client):
     assert response.status_code == 401
 
 
+def test_options_users_without_authorization(client):
+    response = client.open("/api/users", method="OPTIONS")
+    assert response.status_code != 401
+
+
 def test_auth_proxy_failure(client, monkeypatch):
     def fail_request(*args, **kwargs):
         raise requests.RequestException()


### PR DESCRIPTION
## Summary
- allow the JWT middleware to pass through OPTIONS requests without validation
- add a regression test ensuring OPTIONS /api/users works without Authorization

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d78a9cdef48332b42a9cb5a684c270