### PR TITLE
Ensure default permissive CORS behavior

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -31,9 +31,13 @@ def create_app():
     app.config["RATE_LIMIT_AUTH"] = os.getenv("RATE_LIMIT_AUTH", "10/minute")
 
     # CORS configuration
-    origins_env = os.getenv("CORS_ORIGINS", "")
-    origins = [o.strip() for o in origins_env.split(",") if o.strip()]
-    CORS(app, origins=origins)
+    origins_env = os.getenv("CORS_ORIGINS")
+    origins = []
+    if origins_env:
+        origins = [o.strip() for o in origins_env.split(",") if o.strip()]
+
+    cors_kwargs = {"origins": origins} if origins else {}
+    CORS(app, **cors_kwargs)
 
     # Rate limiter initialization
     limiter.init_app(app)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -51,3 +51,25 @@ def test_auth_proxy_failure(client, monkeypatch):
     )
     response = client.post("/api/auth/login")
     assert response.status_code == 502
+
+
+def test_cors_allows_any_origin_when_env_absent(monkeypatch):
+    monkeypatch.delenv("CORS_ORIGINS", raising=False)
+    monkeypatch.setenv("USER_SERVICE_URL", "http://upstream")
+    monkeypatch.setenv("JWT_SECRET", "secret")
+    monkeypatch.setenv("RATE_LIMIT_AUTH", "10/minute")
+
+    mock_resp = Mock()
+    mock_resp.status_code = 200
+    monkeypatch.setattr(
+        "src.app.requests.get", lambda *args, **kwargs: mock_resp
+    )
+
+    app = create_app()
+    app.config["TESTING"] = True
+    client = app.test_client()
+
+    origin = "https://example.com"
+    response = client.get("/health", headers={"Origin": origin})
+
+    assert response.headers.get("Access-Control-Allow-Origin") == origin


### PR DESCRIPTION
## Summary
- allow Flask-CORS to fall back to the default permissive behaviour when no origins are configured
- add a regression test to ensure arbitrary origins remain allowed when CORS_ORIGINS is unset

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d78a9ecc148332988526e8809fde7d