### PR TITLE
Return 503 when user service health check fails

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -61,11 +61,13 @@ def create_app():
                     status = "up"
             except requests.RequestException:
                 pass
+        overall_status = "ok" if status == "up" else "error"
+        http_status = 200 if status == "up" else 503
         return jsonify({
-            "status": "ok",
+            "status": overall_status,
             "service": "api-gateway",
             "upstreams": {"user_service": status},
-        })
+        }), http_status
 
     @app.errorhandler(429)
     def ratelimit_handler(e):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -38,6 +38,18 @@ def test_health(client):
     assert response.json["upstreams"]["user_service"] == "up"
 
 
+def test_health_upstream_down(client, monkeypatch):
+    def fail_health(*args, **kwargs):
+        raise requests.RequestException()
+
+    monkeypatch.setattr("src.app.requests.get", fail_health)
+
+    response = client.get("/health")
+    assert response.status_code == 503
+    assert response.json["status"] == "error"
+    assert response.json["upstreams"]["user_service"] == "down"
+
+
 def test_users_requires_jwt(client):
     response = client.get("/api/users/me")
     assert response.status_code == 401


### PR DESCRIPTION
## Summary
- return a 503 response and error status when the user service health check fails
- add a regression test to ensure the API gateway propagates upstream downtime in /health

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d78a9fd4e08332bb0ba6b42535f478