### PR TITLE
Allow OPTIONS requests without JWT

### DIFF
--- a/src/middleware/jwt.py
+++ b/src/middleware/jwt.py
@@ -8,7 +8,7 @@ def require_jwt(fn):
     @wraps(fn)
     def wrapper(*args, **kwargs):
         if request.method == "OPTIONS":
-            return fn(*args, **kwargs)
+            return current_app.make_default_options_response()
         auth_header = request.headers.get("Authorization", "")
         if not auth_header.startswith("Bearer "):
             return jsonify({"error": "Unauthorized"}), 401

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -56,7 +56,7 @@ def test_users_requires_jwt(client):
 
 
 def test_options_users_without_authorization(client):
-    response = client.open("/api/users", method="OPTIONS")
+    response = client.options("/api/users")
     assert response.status_code != 401
 
 


### PR DESCRIPTION
## Summary
- return Flask's default OPTIONS response when a protected endpoint receives an OPTIONS request so it bypasses JWT validation
- cover the behaviour with a test ensuring OPTIONS on /api/users succeeds without Authorization

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d96281766c8332b2fcc07827554f5a