### PR TITLE
Allow all origins fallback when CORS_ORIGINS unset

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -36,7 +36,7 @@ def create_app():
     if origins_env:
         origins = [o.strip() for o in origins_env.split(",") if o.strip()]
 
-    cors_kwargs = {"origins": origins} if origins else {}
+    cors_kwargs = {"origins": origins if origins else "*"}
     CORS(app, **cors_kwargs)
 
     # Rate limiter initialization


### PR DESCRIPTION
## Summary
- default the CORS configuration to allow all origins when the environment variable is empty or missing
- add reusable test helper and coverage verifying Access-Control-Allow-Origin for arbitrary origins when no CORS origins are configured

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9669a42e88332afe344c710624053