### PR TITLE
Ensure health endpoint reports upstream failures

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -56,21 +56,24 @@ def create_app():
         Returns:
             Response: JSON response with health status of gateway and upstream services.
         """
-        status = "down"
+        upstream_status = "down"
+        overall_status = "down"
+        http_status = 503
+
         url = app.config["USER_SERVICE_URL"].rstrip("/")
         if url:
             try:
                 resp = requests.get(f"{url}/health", timeout=5)
                 if resp.status_code == 200:
-                    status = "up"
+                    upstream_status = "up"
+                    overall_status = "up"
+                    http_status = 200
             except requests.RequestException:
                 pass
-        overall_status = "ok" if status == "up" else "error"
-        http_status = 200 if status == "up" else 503
         return jsonify({
             "status": overall_status,
             "service": "api-gateway",
-            "upstreams": {"user_service": status},
+            "upstreams": {"user_service": upstream_status},
         }), http_status
 
     @app.errorhandler(429)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -52,6 +52,7 @@ def client(app):
 def test_health(client):
     response = client.get("/health")
     assert response.status_code == 200
+    assert response.json["status"] == "up"
     assert response.json["upstreams"]["user_service"] == "up"
 
 
@@ -63,7 +64,7 @@ def test_health_upstream_down(client, monkeypatch):
 
     response = client.get("/health")
     assert response.status_code == 503
-    assert response.json["status"] == "error"
+    assert response.json["status"] == "down"
     assert response.json["upstreams"]["user_service"] == "down"
 
 


### PR DESCRIPTION
## Summary
- align the health endpoint status with upstream availability and return HTTP 503 when the upstream is unreachable
- update health endpoint tests to cover the global status propagation when the upstream call fails

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d967e5e5108332a9778a4216eeb675