### PR TITLE
Add service discovery and resilience features to proxy

### DIFF
--- a/docs/operations/service-discovery.md
+++ b/docs/operations/service-discovery.md
@@ -1,0 +1,64 @@
+# Service discovery et résilience du proxy
+
+Ce document décrit la configuration du registre de services et des mécanismes de
+résilience intégrés à l'API Gateway.
+
+## Variables d'environnement
+
+La factory `create_app` lit les variables ci-dessous pour configurer le registre
+et le middleware de résilience :
+
+| Variable | Description | Valeur par défaut |
+| --- | --- | --- |
+| `USER_SERVICE_NAME` | Nom logique du service utilisateur. | `user-service` |
+| `USER_SERVICE_URL` | URL utilisée comme repli si aucune instance n'est découverte. | *(vide)* |
+| `USER_SERVICE_STATIC_INSTANCES` | Liste d'instances statiques séparées par des virgules. Chaque entrée peut contenir un poids sous la forme `https://exemple:8443|3`. | *(vide)* |
+| `SERVICE_DISCOVERY_BACKEND` | Type de backend de découverte (`static` pour le moment). | `static` |
+| `SERVICE_DISCOVERY_REFRESH_INTERVAL` | Durée (secondes) avant de rafraîchir le cache d'instances. | `30` |
+| `LOAD_BALANCER_STRATEGY` | Stratégie de sélection (`round_robin`, `weighted`, `health`). | `round_robin` |
+| `PROXY_TIMEOUT_CONNECT` | Timeout de connexion (secondes) côté proxy. | `2` |
+| `PROXY_TIMEOUT_READ` | Timeout de lecture (secondes) côté proxy. | `10` |
+| `RESILIENCE_MAX_RETRIES` | Nombre de nouvelles tentatives autorisées par requête. | `2` |
+| `RESILIENCE_BACKOFF_FACTOR` | Facteur du backoff exponentiel (doublé à chaque tentative). | `0.5` |
+| `RESILIENCE_MAX_BACKOFF` | Backoff maximum (secondes). | `5` |
+| `CIRCUIT_BREAKER_FAILURE_THRESHOLD` | Nombre d'échecs successifs avant d'ouvrir le circuit. | `3` |
+| `CIRCUIT_BREAKER_RESET_TIMEOUT` | Temps d'attente (secondes) avant de retenter un appel sur un circuit ouvert. | `30` |
+
+## Stratégies de sélection d'instance
+
+Le module `src/services/registry.py` expose plusieurs stratégies de
+répartition. Elles peuvent être choisies via `LOAD_BALANCER_STRATEGY` et sont
+écrites sous forme de plug-ins pouvant être étendus avec `register_strategy`.
+
+- **round_robin** : alterne entre les instances disponibles en privilégiant les
+  instances considérées comme saines.
+- **weighted** : applique un round-robin déterministe où chaque instance est
+  répliquée selon son poids (`weight`).
+- **health** : privilégie les instances marquées saines et repasse en mode
+  round-robin classique si toutes sont en échec.
+
+Les instances statiques se déclarent via `USER_SERVICE_STATIC_INSTANCES` :
+
+```text
+https://svc-a.example|2,https://svc-b.example,https://svc-c.example|4
+```
+
+Ici `svc-c` recevra quatre fois plus de trafic que `svc-b` et deux fois plus que
+`svc-a`.
+
+## Middleware de résilience
+
+`src/middleware/resilience.py` fournit :
+
+- **Circuit breaker** : lorsqu'un nombre d'échecs consécutifs atteint
+  `CIRCUIT_BREAKER_FAILURE_THRESHOLD`, l'instance est mise hors-circuit pendant
+  `CIRCUIT_BREAKER_RESET_TIMEOUT` secondes.
+- **Retry exponentiel** : les appels en échec sont retentés sur d'autres
+  instances avec un délai initial `RESILIENCE_BACKOFF_FACTOR` et un maximum
+  `RESILIENCE_MAX_BACKOFF`.
+- **Bascule automatique** : en cas d'échec, le proxy sélectionne une autre
+  instance disponible selon la stratégie configurée.
+
+Quand toutes les instances échouent ou que les circuits sont ouverts, l'API
+Gateway répond `503 Service Unavailable`. Les erreurs réseau ou les timeouts
+épuisant toutes les tentatives déclenchent une réponse `502 Bad Gateway`.

--- a/src/app.py
+++ b/src/app.py
@@ -12,6 +12,8 @@ from flask_limiter.util import get_remote_address
 from werkzeug.exceptions import HTTPException
 
 from .middleware.logging import setup_request_logging
+from .middleware.resilience import ResilienceMiddleware
+from .services.registry import create_service_registry
 from .utils.responses import error_response
 
 limiter = Limiter(key_func=get_remote_address)
@@ -58,8 +60,36 @@ def create_app() -> Flask:
     app = Flask(__name__)
 
     app.config["USER_SERVICE_URL"] = os.getenv("USER_SERVICE_URL", "")
+    app.config["USER_SERVICE_NAME"] = os.getenv("USER_SERVICE_NAME", "user-service")
+    app.config["USER_SERVICE_STATIC_INSTANCES"] = os.getenv(
+        "USER_SERVICE_STATIC_INSTANCES", ""
+    )
+    app.config["SERVICE_DISCOVERY_BACKEND"] = os.getenv(
+        "SERVICE_DISCOVERY_BACKEND", "static"
+    )
+    app.config["SERVICE_DISCOVERY_REFRESH_INTERVAL"] = float(
+        os.getenv("SERVICE_DISCOVERY_REFRESH_INTERVAL", "30")
+    )
+    app.config["LOAD_BALANCER_STRATEGY"] = os.getenv(
+        "LOAD_BALANCER_STRATEGY", "round_robin"
+    )
     app.config["JWT_SECRET"] = os.getenv("JWT_SECRET", "")
     app.config["RATE_LIMIT_AUTH"] = os.getenv("RATE_LIMIT_AUTH", "10/minute")
+    app.config["PROXY_TIMEOUT_CONNECT"] = float(os.getenv("PROXY_TIMEOUT_CONNECT", "2"))
+    app.config["PROXY_TIMEOUT_READ"] = float(os.getenv("PROXY_TIMEOUT_READ", "10"))
+    app.config["RESILIENCE_MAX_RETRIES"] = int(os.getenv("RESILIENCE_MAX_RETRIES", "2"))
+    app.config["RESILIENCE_BACKOFF_FACTOR"] = float(
+        os.getenv("RESILIENCE_BACKOFF_FACTOR", "0.5")
+    )
+    app.config["RESILIENCE_MAX_BACKOFF"] = float(
+        os.getenv("RESILIENCE_MAX_BACKOFF", "5")
+    )
+    app.config["CIRCUIT_BREAKER_FAILURE_THRESHOLD"] = int(
+        os.getenv("CIRCUIT_BREAKER_FAILURE_THRESHOLD", "3")
+    )
+    app.config["CIRCUIT_BREAKER_RESET_TIMEOUT"] = float(
+        os.getenv("CIRCUIT_BREAKER_RESET_TIMEOUT", "30")
+    )
 
     _configure_logging(app)
     setup_request_logging(app)
@@ -68,6 +98,15 @@ def create_app() -> Flask:
     limiter.init_app(app)
 
     from .routes.proxy import proxy_bp
+
+    app.extensions["service_registry"] = create_service_registry(app.config)
+    app.extensions["resilience_middleware"] = ResilienceMiddleware(
+        failure_threshold=app.config["CIRCUIT_BREAKER_FAILURE_THRESHOLD"],
+        recovery_time=app.config["CIRCUIT_BREAKER_RESET_TIMEOUT"],
+        max_retries=app.config["RESILIENCE_MAX_RETRIES"],
+        backoff_factor=app.config["RESILIENCE_BACKOFF_FACTOR"],
+        max_backoff=app.config["RESILIENCE_MAX_BACKOFF"],
+    )
 
     app.register_blueprint(proxy_bp)
 

--- a/src/middleware/resilience.py
+++ b/src/middleware/resilience.py
@@ -1,0 +1,174 @@
+"""Resilience middleware providing retries and circuit breaking."""
+
+from __future__ import annotations
+
+import math
+import threading
+import time
+from dataclasses import dataclass
+from typing import Callable, Dict, Iterable, List, Sequence
+
+from ..services.registry import ServiceInstance, ServiceRegistry
+
+
+class ResilienceError(Exception):
+    """Base error raised by the resilience middleware."""
+
+
+class ServiceUnavailableError(ResilienceError):
+    """Raised when no upstream instances are available."""
+
+
+class UpstreamServiceError(ResilienceError):
+    """Raised when upstream calls fail after exhausting retries."""
+
+    def __init__(self, message: str, *, response=None) -> None:
+        super().__init__(message)
+        self.response = response
+
+
+class UpstreamRequestError(Exception):
+    """Internal wrapper for upstream request failures."""
+
+
+@dataclass
+class _CircuitBreakerState:
+    failures: int = 0
+    opened_at: float | None = None
+    half_open: bool = False
+
+
+class ResilienceMiddleware:
+    """Apply retry, exponential backoff and circuit breaking logic."""
+
+    def __init__(
+        self,
+        *,
+        failure_threshold: int = 3,
+        recovery_time: float = 30.0,
+        max_retries: int = 2,
+        backoff_factor: float = 0.5,
+        max_backoff: float = 5.0,
+        time_func: Callable[[], float] | None = None,
+        sleep_func: Callable[[float], None] | None = None,
+    ) -> None:
+        self.failure_threshold = max(failure_threshold, 1)
+        self.recovery_time = max(recovery_time, 0.0)
+        self.max_retries = max(max_retries, 0)
+        self.backoff_factor = max(backoff_factor, 0.0)
+        self.max_backoff = max(max_backoff, 0.0)
+        self._time_func = time_func or time.monotonic
+        self._sleep_func = sleep_func or time.sleep
+        self._lock = threading.Lock()
+        self._circuits: Dict[str, _CircuitBreakerState] = {}
+
+    def execute(
+        self,
+        *,
+        registry: ServiceRegistry,
+        service_name: str,
+        strategy_name: str,
+        request_func: Callable[[ServiceInstance], object],
+    ):
+        """Execute a request against the registry using failover semantics."""
+
+        excluded: set[str] = set()
+        last_error: Exception | None = None
+
+        for attempt in range(self.max_retries + 1):
+            force_refresh = attempt > 0
+            instances = registry.get_instances(service_name, force_refresh=force_refresh)
+            candidates = self._filter_instances(instances, excluded)
+            if not candidates:
+                candidates = self._filter_instances(instances, set())
+            if not candidates:
+                raise ServiceUnavailableError(f"No available instances for {service_name}")
+
+            try:
+                instance = registry.select_instance(
+                    service_name,
+                    strategy_name,
+                    instances=candidates,
+                )
+            except (LookupError, ValueError):
+                raise ServiceUnavailableError(f"No available instances for {service_name}")
+
+            try:
+                response = request_func(instance)
+            except UpstreamRequestError as exc:
+                last_error = exc
+                self._record_failure(instance)
+                excluded.add(instance.identity)
+                if attempt < self.max_retries:
+                    self._sleep(attempt)
+                    continue
+                raise UpstreamServiceError("Upstream request failed") from exc
+
+            status_code = getattr(response, "status_code", None)
+            if isinstance(status_code, int) and status_code >= 500:
+                last_error = UpstreamServiceError(
+                    f"Upstream returned status {status_code}", response=response
+                )
+                self._record_failure(instance)
+                excluded.add(instance.identity)
+                if attempt < self.max_retries:
+                    self._sleep(attempt)
+                    continue
+                return response
+
+            self._record_success(instance)
+            if hasattr(response, "status_code") and status_code is not None and status_code < 500:
+                instance.healthy = True
+            return response
+
+        if isinstance(last_error, UpstreamServiceError) and last_error.response is not None:
+            return last_error.response
+        raise ServiceUnavailableError(f"Unable to reach service {service_name}")
+
+    def _sleep(self, attempt: int) -> None:
+        if self.backoff_factor == 0:
+            return
+        delay = self.backoff_factor * math.pow(2, attempt)
+        if self.max_backoff:
+            delay = min(delay, self.max_backoff)
+        if delay > 0:
+            self._sleep_func(delay)
+
+    def _filter_instances(
+        self, instances: Sequence[ServiceInstance], excluded: Iterable[str]
+    ) -> List[ServiceInstance]:
+        now = self._time_func()
+        excluded_set = set(excluded)
+        result: List[ServiceInstance] = []
+        for instance in instances:
+            if instance.identity in excluded_set:
+                continue
+            state = self._get_state(instance.identity)
+            if state.opened_at is None:
+                result.append(instance)
+                continue
+            if now - state.opened_at >= self.recovery_time:
+                state.half_open = True
+                state.opened_at = None
+                result.append(instance)
+        return result
+
+    def _get_state(self, identity: str) -> _CircuitBreakerState:
+        with self._lock:
+            return self._circuits.setdefault(identity, _CircuitBreakerState())
+
+    def _record_failure(self, instance: ServiceInstance) -> None:
+        state = self._get_state(instance.identity)
+        state.failures += 1
+        instance.healthy = False
+        if state.failures >= self.failure_threshold and state.opened_at is None:
+            state.opened_at = self._time_func()
+            state.half_open = False
+
+    def _record_success(self, instance: ServiceInstance) -> None:
+        state = self._get_state(instance.identity)
+        state.failures = 0
+        state.half_open = False
+        state.opened_at = None
+        instance.healthy = True
+

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -1,0 +1,2 @@
+"""Service layer helpers for the API gateway."""
+

--- a/src/services/registry.py
+++ b/src/services/registry.py
@@ -1,0 +1,247 @@
+"""Service discovery and load-balancing helpers."""
+
+from __future__ import annotations
+
+import itertools
+import threading
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Mapping, MutableSequence, Sequence, Tuple
+
+
+@dataclass(slots=True)
+class ServiceInstance:
+    """Describe a discovered service instance."""
+
+    service_name: str
+    url: str
+    weight: int = 1
+    healthy: bool = True
+    metadata: Mapping[str, str] | None = None
+
+    def __post_init__(self) -> None:
+        if self.weight < 1:
+            self.weight = 1
+
+    @property
+    def identity(self) -> str:
+        """Return a stable identifier for the instance."""
+
+        return f"{self.service_name}:{self.url}"
+
+
+class RegistryBackend:
+    """Interface for registry backends."""
+
+    def list_instances(self, service_name: str) -> Sequence[ServiceInstance]:  # pragma: no cover - documentation
+        raise NotImplementedError
+
+
+class StaticRegistryBackend(RegistryBackend):
+    """Backend that serves instances from static configuration."""
+
+    def __init__(self, services: Mapping[str, Sequence[ServiceInstance]]):
+        self._services = services
+
+    def list_instances(self, service_name: str) -> Sequence[ServiceInstance]:
+        return list(self._services.get(service_name, ()))
+
+
+class LoadBalancingStrategy:
+    """Base interface for load balancing strategies."""
+
+    def select(self, instances: Sequence[ServiceInstance]) -> ServiceInstance:  # pragma: no cover - documentation
+        raise NotImplementedError
+
+
+class RoundRobinStrategy(LoadBalancingStrategy):
+    """Return instances in a round-robin fashion preferring healthy ones."""
+
+    def __init__(self) -> None:
+        self._counter = itertools.count()
+        self._lock = threading.Lock()
+
+    def select(self, instances: Sequence[ServiceInstance]) -> ServiceInstance:
+        candidates = _prioritize_healthy(instances)
+        if not candidates:
+            raise ValueError("No instances available")
+
+        with self._lock:
+            index = next(self._counter)
+            return candidates[index % len(candidates)]
+
+
+class WeightedRoundRobinStrategy(LoadBalancingStrategy):
+    """Return instances using deterministic weighted round robin."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._sequence: MutableSequence[ServiceInstance] = []
+        self._counter = 0
+        self._fingerprint: Tuple[Tuple[str, int, bool], ...] | None = None
+
+    def select(self, instances: Sequence[ServiceInstance]) -> ServiceInstance:
+        candidates = _prioritize_healthy(instances)
+        if not candidates:
+            raise ValueError("No instances available")
+
+        fingerprint = tuple((inst.identity, inst.weight, inst.healthy) for inst in candidates)
+        if fingerprint != self._fingerprint:
+            expanded: List[ServiceInstance] = []
+            for inst in candidates:
+                expanded.extend([inst] * inst.weight)
+            self._sequence = expanded or list(candidates)
+            self._counter = 0
+            self._fingerprint = fingerprint
+
+        with self._lock:
+            if not self._sequence:
+                raise ValueError("No instances available")
+            inst = self._sequence[self._counter % len(self._sequence)]
+            self._counter += 1
+            return inst
+
+
+class HealthAwareStrategy(LoadBalancingStrategy):
+    """Prefer healthy instances while allowing graceful degradation."""
+
+    def __init__(self) -> None:
+        self._delegate = RoundRobinStrategy()
+
+    def select(self, instances: Sequence[ServiceInstance]) -> ServiceInstance:
+        healthy = [inst for inst in instances if inst.healthy]
+        if healthy:
+            return self._delegate.select(healthy)
+        return self._delegate.select(instances)
+
+
+StrategyFactory = Callable[[], LoadBalancingStrategy]
+
+
+_STRATEGIES: Dict[str, StrategyFactory] = {
+    "round_robin": RoundRobinStrategy,
+    "weighted": WeightedRoundRobinStrategy,
+    "health": HealthAwareStrategy,
+}
+
+
+def register_strategy(name: str, factory: StrategyFactory) -> None:
+    """Register a new load balancing strategy."""
+
+    _STRATEGIES[name.lower()] = factory
+
+
+def create_strategy(name: str) -> LoadBalancingStrategy:
+    """Create a load balancing strategy by name."""
+
+    try:
+        factory = _STRATEGIES[name.lower()]
+    except KeyError as exc:  # pragma: no cover - defensive
+        raise ValueError(f"Unknown strategy '{name}'") from exc
+    return factory()
+
+
+def _prioritize_healthy(instances: Sequence[ServiceInstance]) -> List[ServiceInstance]:
+    healthy = [inst for inst in instances if inst.healthy]
+    return healthy or list(instances)
+
+
+class ServiceRegistry:
+    """High level interface to service discovery backends."""
+
+    def __init__(
+        self,
+        backend: RegistryBackend,
+        *,
+        refresh_interval: float = 30.0,
+        strategy_resolver: Callable[[str], LoadBalancingStrategy] | None = None,
+    ) -> None:
+        self._backend = backend
+        self._refresh_interval = max(refresh_interval, 0.0)
+        self._strategy_resolver = strategy_resolver
+        self._cache: Dict[str, Tuple[float, List[ServiceInstance]]] = {}
+        self._strategies: Dict[Tuple[str, str], LoadBalancingStrategy] = {}
+        self._lock = threading.Lock()
+
+    def get_instances(self, service_name: str, *, force_refresh: bool = False, now: float | None = None) -> List[ServiceInstance]:
+        """Return cached instances, refreshing when needed."""
+
+        import time
+
+        timestamp = now if now is not None else time.monotonic()
+        with self._lock:
+            cached = self._cache.get(service_name)
+            if (
+                not cached
+                or force_refresh
+                or (self._refresh_interval and timestamp - cached[0] > self._refresh_interval)
+            ):
+                instances = list(self._backend.list_instances(service_name))
+                self._cache[service_name] = (timestamp, instances)
+            return list(self._cache[service_name][1])
+
+    def select_instance(
+        self,
+        service_name: str,
+        strategy: str,
+        *,
+        instances: Sequence[ServiceInstance] | None = None,
+    ) -> ServiceInstance:
+        """Select an instance using the requested strategy."""
+
+        available = list(instances) if instances is not None else self.get_instances(service_name)
+        if not available:
+            raise LookupError(f"No instances registered for {service_name}")
+
+        key = (service_name, strategy.lower())
+        if key not in self._strategies:
+            if self._strategy_resolver:
+                self._strategies[key] = self._strategy_resolver(strategy)
+            else:
+                self._strategies[key] = create_strategy(strategy)
+
+        return self._strategies[key].select(available)
+
+
+def parse_static_instances(
+    service_name: str,
+    raw: str,
+) -> List[ServiceInstance]:
+    """Parse a comma separated list of ``url|weight`` definitions."""
+
+    instances: List[ServiceInstance] = []
+    for chunk in (part.strip() for part in raw.split(",") if part.strip()):
+        if "|" in chunk:
+            url, weight_str = chunk.split("|", 1)
+            try:
+                weight = int(weight_str)
+            except ValueError:
+                weight = 1
+        else:
+            url = chunk
+            weight = 1
+        instances.append(ServiceInstance(service_name=service_name, url=url.strip(), weight=weight))
+    return instances
+
+
+def create_service_registry(config: Mapping[str, object]) -> ServiceRegistry:
+    """Instantiate a service registry from the Flask configuration."""
+
+    service_name = str(config.get("USER_SERVICE_NAME", "user-service"))
+    backend_name = str(config.get("SERVICE_DISCOVERY_BACKEND", "static")).lower()
+    refresh_interval = float(config.get("SERVICE_DISCOVERY_REFRESH_INTERVAL", 30.0))
+
+    static_value = str(config.get("USER_SERVICE_STATIC_INSTANCES", ""))
+    instances = parse_static_instances(service_name, static_value)
+    if not instances:
+        url = str(config.get("USER_SERVICE_URL", ""))
+        if url:
+            instances.append(ServiceInstance(service_name=service_name, url=url))
+
+    backend: RegistryBackend
+    if backend_name == "static":
+        backend = StaticRegistryBackend({service_name: instances})
+    else:  # pragma: no cover - placeholder for future providers
+        backend = StaticRegistryBackend({service_name: instances})
+
+    return ServiceRegistry(backend, refresh_interval=refresh_interval)
+

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -29,6 +29,7 @@ def _create_app_without_cors_origins(monkeypatch):
     monkeypatch.setenv("USER_SERVICE_URL", "http://upstream")
     monkeypatch.setenv("JWT_SECRET", "secret")
     monkeypatch.setenv("RATE_LIMIT_AUTH", "10/minute")
+    monkeypatch.setenv("RESILIENCE_BACKOFF_FACTOR", "0")
 
     mock_resp = Mock()
     mock_resp.status_code = 200
@@ -47,6 +48,7 @@ def app(monkeypatch):
     os.environ["CORS_ORIGINS"] = ""
     os.environ["JWT_SECRET"] = "secret"
     os.environ["RATE_LIMIT_AUTH"] = "10/minute"
+    os.environ["RESILIENCE_BACKOFF_FACTOR"] = "0"
 
     mock_resp = Mock()
     mock_resp.status_code = 200
@@ -126,7 +128,7 @@ def test_proxy_preserves_duplicate_query_params(client, monkeypatch):
 
     assert response.status_code == 200
     assert captured["params"] == [("tag", "a"), ("tag", "b")]
-    assert captured["timeout"] == (2, 10)
+    assert captured["timeout"] == (2.0, 10.0)
 
 
 def test_proxy_preserves_multiple_set_cookie_headers(client, monkeypatch):

--- a/tests/test_service_discovery.py
+++ b/tests/test_service_discovery.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+from typing import List
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+from src.app import create_app
+from src.middleware.resilience import ResilienceMiddleware
+from src.services.registry import (
+    ServiceInstance,
+    ServiceRegistry,
+    StaticRegistryBackend,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_env(monkeypatch):
+    monkeypatch.setenv("USER_SERVICE_URL", "http://upstream")
+    monkeypatch.setenv("USER_SERVICE_NAME", "user-service")
+    monkeypatch.setenv("SERVICE_DISCOVERY_BACKEND", "static")
+    monkeypatch.setenv("SERVICE_DISCOVERY_REFRESH_INTERVAL", "0")
+    monkeypatch.setenv("RESILIENCE_BACKOFF_FACTOR", "0")
+    monkeypatch.setenv("RESILIENCE_MAX_RETRIES", "1")
+    monkeypatch.setenv("CIRCUIT_BREAKER_FAILURE_THRESHOLD", "2")
+    monkeypatch.setenv("CIRCUIT_BREAKER_RESET_TIMEOUT", "60")
+    yield
+
+
+def _make_registry(instances: List[ServiceInstance]) -> ServiceRegistry:
+    backend = StaticRegistryBackend({instances[0].service_name: instances})
+    return ServiceRegistry(backend, refresh_interval=0)
+
+
+def test_round_robin_strategy_cycles_instances():
+    registry = _make_registry(
+        [
+            ServiceInstance("user-service", "http://a"),
+            ServiceInstance("user-service", "http://b"),
+        ]
+    )
+
+    first = registry.select_instance("user-service", "round_robin")
+    second = registry.select_instance("user-service", "round_robin")
+    third = registry.select_instance("user-service", "round_robin")
+
+    assert [inst.url for inst in (first, second, third)] == [
+        "http://a",
+        "http://b",
+        "http://a",
+    ]
+
+
+def test_health_strategy_prefers_healthy_instances():
+    instances = [
+        ServiceInstance("user-service", "http://a", healthy=False),
+        ServiceInstance("user-service", "http://b", healthy=True),
+    ]
+    registry = _make_registry(instances)
+
+    selected = registry.select_instance("user-service", "health")
+    assert selected.url == "http://b"
+
+
+def test_weighted_strategy_repeats_instances_by_weight():
+    registry = _make_registry(
+        [
+            ServiceInstance("user-service", "http://a", weight=2),
+            ServiceInstance("user-service", "http://b", weight=1),
+        ]
+    )
+
+    sequence = [registry.select_instance("user-service", "weighted").url for _ in range(3)]
+    assert sequence.count("http://a") == 2
+    assert sequence.count("http://b") == 1
+
+
+def test_proxy_failover_between_instances(monkeypatch):
+    monkeypatch.setenv(
+        "USER_SERVICE_STATIC_INSTANCES", "http://svc-a,http://svc-b"
+    )
+    app = create_app()
+    app.config["TESTING"] = True
+    middleware: ResilienceMiddleware = app.extensions["resilience_middleware"]
+    middleware.backoff_factor = 0
+
+    calls: list[str] = []
+
+    def fake_request(method, url, **kwargs):
+        calls.append(url)
+        if "svc-a" in url:
+            raise requests.RequestException("boom")
+        mock_resp = Mock()
+        mock_resp.status_code = 200
+        mock_resp.content = b"{}"
+        mock_resp.headers = {}
+        mock_resp.raw = Mock(headers={})
+        return mock_resp
+
+    monkeypatch.setattr("src.routes.proxy.requests.request", fake_request)
+
+    with app.test_client() as client:
+        response = client.get("/api/auth/session")
+
+    assert response.status_code == 200
+    assert len(calls) == 2
+    assert any("svc-a" in url for url in calls)
+    assert any("svc-b" in url for url in calls)
+
+
+def test_circuit_breaker_opens_after_failures(monkeypatch):
+    monkeypatch.setenv("USER_SERVICE_STATIC_INSTANCES", "http://svc-a")
+    monkeypatch.setenv("RESILIENCE_MAX_RETRIES", "0")
+
+    app = create_app()
+    app.config["TESTING"] = True
+    middleware: ResilienceMiddleware = app.extensions["resilience_middleware"]
+
+    current_time = [0.0]
+
+    def fake_time():
+        return current_time[0]
+
+    middleware._time_func = fake_time  # type: ignore[attr-defined]
+    middleware.backoff_factor = 0
+
+    calls = 0
+
+    def failing_request(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        raise requests.RequestException("down")
+
+    monkeypatch.setattr("src.routes.proxy.requests.request", failing_request)
+
+    with app.test_client() as client:
+        first = client.get("/api/auth/session")
+        second = client.get("/api/auth/session")
+        current_time[0] += 10
+        third = client.get("/api/auth/session")
+
+    assert first.status_code == 502
+    assert second.status_code == 502
+    assert third.status_code == 503
+    assert calls == 2


### PR DESCRIPTION
## Summary
- add a service registry module with pluggable load-balancing strategies and wire it into the Flask app configuration
- introduce a resilience middleware implementing retries, circuit breaking, and failover and integrate it with the proxy forwarding flow
- document the service-discovery configuration and add tests covering selection strategies, failover, and circuit breaker scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d993fd523c8332a0c2d57978ba4dcc