### PR TITLE
Add security middleware for API keys, OAuth, and signatures

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,63 @@
+# Sécurité du portail Meetinity
+
+Ce document décrit les mécanismes de sécurité exposés par la passerelle :
+
+- gestion des clés API et du middleware associé ;
+- intégration OAuth 2.0 / OpenID Connect ;
+- signature HMAC des requêtes et vérification côté passerelle ;
+- filtrage IP (listes blanches/noires) et limitation par client.
+
+## Clés API
+
+Les clés sont définies via la variable d'environnement `API_KEYS` au format
+`<identifiant>:<secret>` séparés par des virgules. Les secrets sont salés et
+hachés (`API_KEY_SALT`, `API_KEY_HASH_ALGORITHM`) avant d'être stockés en
+mémoire. Le middleware `APIKeyMiddleware` impose la présence de l'en-tête
+`API_KEY_HEADER` (par défaut `X-API-Key`) sur toutes les routes non listées dans
+`API_KEY_EXEMPT_PATHS`.
+
+- Activer/désactiver : `API_KEY_REQUIRED` (`true` par défaut si des clés sont
+  configurées).
+- Exemptions : valeur séparée par des virgules, `/health` est appliqué par
+  défaut.
+
+## OAuth 2.0 / OpenID Connect
+
+Lorsqu'`OAUTH_PROVIDER_URL` est défini, la passerelle instancie un
+`OIDCProvider` qui réalise la découverte de métadonnées (`/.well-known/openid-configuration`)
+avec un cache configurable (`OAUTH_CACHE_TTL`). Le validateur supporte les
+jetons HMAC (`client_secret`) et RSA (JWKS), vérifie l'issuer, l'audience et les
+claims obligatoires (`exp`, `iat`). Les paramètres optionnels :
+
+- `OAUTH_AUDIENCE` pour l'audience attendue côté passerelle ;
+- `OAUTH_CLIENT_SECRET` pour les signatures HMAC.
+
+Les erreurs de validation retournent des exceptions `TokenValidationError` et la
+métadonnée est exposée via `app.extensions['oidc_provider']`.
+
+## Signatures HMAC des requêtes
+
+Le middleware `RequestSignatureMiddleware` valide les requêtes entrantes à l'aide
+d'une signature HMAC SHA-256 sur une représentation canonique : méthode,
+chemin, corps haché et en-têtes optionnels (`SIGNATURE_HEADERS`). Les secrets
+sont fournis via `SIGNING_SECRETS` (`<client>:<secret>`). Les options :
+
+- `SIGNATURE_HEADER`, `SIGNATURE_TIMESTAMP_HEADER`, `SIGNATURE_KEY_ID_HEADER` ;
+- `SIGNATURE_ALGORITHM` (algo HMAC, défaut `sha256`) ;
+- `SIGNATURE_CLOCK_TOLERANCE` (en secondes, défaut 300) ;
+- `SIGNATURE_EXEMPT_PATHS` (par défaut `/health`) ;
+- `REQUEST_SIGNATURES_ENABLED` pour activer/désactiver (activé automatiquement
+  si des secrets sont fournis).
+
+L'outil `RequestSigner` facilite la génération de signatures côté client.
+
+## Filtrage IP et limitation
+
+Les variables `IP_WHITELIST` et `IP_BLACKLIST` permettent de restreindre l'accès
+par adresse IP (valeurs séparées par des virgules). Les accès refusés renvoient
+un statut HTTP 403 et sont journalisés.
+
+Le `Limiter` utilise désormais l'en-tête `API_KEY_HEADER` pour dériver la clé de
+limitation : lorsqu'une clé API est fournie, la limite s'applique par client,
+sinon l'adresse IP (`get_remote_address`) est utilisée. Les limites existantes
+(`RATE_LIMIT_AUTH`, etc.) continuent de fonctionner.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ Flask-CORS==4.0.0
 Flask-Limiter==3.5.0
 PyJWT==2.8.0
 python-dotenv==1.0.0
+cryptography==41.0.6
 pytest==7.4.0
 flake8==6.0.0

--- a/src/security/__init__.py
+++ b/src/security/__init__.py
@@ -1,0 +1,13 @@
+"""Security utilities for the Meetinity API Gateway."""
+
+from .api_keys import APIKeyMiddleware, APIKeyStore
+from .oauth import OIDCProvider
+from .signatures import RequestSignatureMiddleware, RequestSigner
+
+__all__ = [
+    "APIKeyMiddleware",
+    "APIKeyStore",
+    "OIDCProvider",
+    "RequestSignatureMiddleware",
+    "RequestSigner",
+]

--- a/src/security/api_keys.py
+++ b/src/security/api_keys.py
@@ -1,0 +1,191 @@
+"""API key management and validation utilities."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import time
+from dataclasses import dataclass
+from typing import Dict, Iterable, Mapping, Optional, Sequence
+
+from flask import Flask, Request, request
+
+from ..utils.responses import error_response
+
+
+DEFAULT_HASH_ALGORITHM = "sha256"
+
+
+def _hash_value(value: str, algorithm: str = DEFAULT_HASH_ALGORITHM) -> str:
+    """Return the hexadecimal digest for ``value`` using ``algorithm``."""
+
+    hasher = hashlib.new(algorithm)
+    hasher.update(value.encode("utf-8"))
+    return hasher.hexdigest()
+
+
+@dataclass(frozen=True)
+class StoredAPIKey:
+    """Represent an API key stored in the gateway."""
+
+    key_id: str
+    hashed_secret: str
+    created_at: float
+
+
+class APIKeyStore:
+    """Securely store API keys as salted hashes and validate presented secrets."""
+
+    def __init__(
+        self,
+        *,
+        keys: Optional[Mapping[str, str]] = None,
+        salt: str = "",
+        algorithm: str = DEFAULT_HASH_ALGORITHM,
+    ) -> None:
+        self._salt = salt
+        self._algorithm = algorithm
+        self._keys: Dict[str, StoredAPIKey] = {}
+        if keys:
+            for key_id, secret in keys.items():
+                self.add_key(key_id, secret, hashed=False)
+
+    @classmethod
+    def from_environment(cls, env: Mapping[str, str] | None = None) -> "APIKeyStore":
+        """Create a key store from environment variables.
+
+        Keys are read from the ``API_KEYS`` variable using the format
+        ``<key-id>:<secret>`` separated by commas. Secrets are hashed immediately
+        using the configured algorithm.
+        """
+
+        env = env or os.environ
+        raw_keys = env.get("API_KEYS", "")
+        salt = env.get("API_KEY_SALT", "")
+        algorithm = env.get("API_KEY_HASH_ALGORITHM", DEFAULT_HASH_ALGORITHM)
+
+        parsed: Dict[str, str] = {}
+        for token in _split_csv(raw_keys):
+            if ":" not in token:
+                continue
+            key_id, secret = token.split(":", 1)
+            key_id = key_id.strip()
+            secret = secret.strip()
+            if key_id and secret:
+                parsed[key_id] = secret
+        return cls(keys=parsed, salt=salt, algorithm=algorithm)
+
+    @property
+    def salt(self) -> str:
+        return self._salt
+
+    @property
+    def algorithm(self) -> str:
+        return self._algorithm
+
+    def add_key(self, key_id: str, secret: str, *, hashed: bool = False) -> None:
+        """Add a new API key to the store."""
+
+        if not key_id:
+            raise ValueError("key_id must not be empty")
+        if not secret:
+            raise ValueError("secret must not be empty")
+
+        stored_secret = secret if hashed else self._hash_secret(secret)
+        self._keys[key_id] = StoredAPIKey(
+            key_id=key_id,
+            hashed_secret=stored_secret,
+            created_at=time.time(),
+        )
+
+    def remove_key(self, key_id: str) -> None:
+        """Remove an API key from the store if it exists."""
+
+        self._keys.pop(key_id, None)
+
+    def validate(self, provided_secret: str) -> bool:
+        """Validate the provided API key secret against stored hashes."""
+
+        if not provided_secret:
+            return False
+        candidate = self._hash_secret(provided_secret)
+        for stored in self._keys.values():
+            if hmac.compare_digest(stored.hashed_secret, candidate):
+                return True
+        return False
+
+    def _hash_secret(self, secret: str) -> str:
+        salted = f"{secret}{self._salt}" if self._salt else secret
+        return _hash_value(salted, self._algorithm)
+
+    def as_dict(self) -> Dict[str, StoredAPIKey]:
+        """Return a shallow copy of stored keys for inspection/testing."""
+
+        return dict(self._keys)
+
+
+def _split_csv(raw: str) -> Sequence[str]:
+    return [token.strip() for token in raw.split(",") if token.strip()]
+
+
+class APIKeyMiddleware:
+    """Flask middleware enforcing API key validation for incoming requests."""
+
+    def __init__(
+        self,
+        app: Flask,
+        store: APIKeyStore,
+        *,
+        header_name: str = "X-API-Key",
+        enabled: bool = True,
+        exempt_paths: Optional[Iterable[str]] = None,
+    ) -> None:
+        self.app = app
+        self.store = store
+        self.header_name = header_name
+        self.enabled = enabled
+        self.exempt_paths = tuple(exempt_paths or ("/health",))
+        if enabled:
+            app.before_request(self._enforce_api_key)
+
+    def _is_exempt(self, req: Request) -> bool:
+        path = req.path or "/"
+        return any(path.startswith(prefix) for prefix in self.exempt_paths)
+
+    def _enforce_api_key(self):
+        if not self.enabled:
+            return None
+        if self._is_exempt(request):
+            return None
+
+        provided = request.headers.get(self.header_name)
+        if not provided:
+            return error_response(401, "API key required")
+        if not self.store.validate(provided):
+            return error_response(403, "Invalid API key")
+        return None
+
+
+def configure_api_keys(app: Flask) -> Optional[APIKeyMiddleware]:
+    """Configure API key middleware from application configuration."""
+
+    store = APIKeyStore.from_environment(app.config)
+    enabled = app.config.get("API_KEY_REQUIRED", bool(store.as_dict()))
+    header_name = app.config.get("API_KEY_HEADER", "X-API-Key")
+    exempt_paths = app.config.get("API_KEY_EXEMPT_PATHS", ("/health",))
+
+    if not enabled:
+        app.logger.info("API key middleware disabled")
+        app.extensions["api_key_store"] = store
+        return None
+
+    middleware = APIKeyMiddleware(
+        app,
+        store,
+        header_name=header_name,
+        enabled=True,
+        exempt_paths=exempt_paths,
+    )
+    app.extensions["api_key_store"] = store
+    return middleware

--- a/src/security/oauth.py
+++ b/src/security/oauth.py
@@ -1,0 +1,182 @@
+"""OAuth 2.0 and OpenID Connect utilities."""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Mapping, Optional
+
+import jwt
+import requests
+from jwt import InvalidTokenError, PyJWTError
+
+
+class DiscoveryError(RuntimeError):
+    """Raised when metadata discovery fails."""
+
+
+class TokenValidationError(RuntimeError):
+    """Raised when a token cannot be validated."""
+
+
+@dataclass
+class ProviderMetadata:
+    """Container for OpenID Connect discovery metadata."""
+
+    issuer: str
+    authorization_endpoint: Optional[str]
+    token_endpoint: Optional[str]
+    jwks_uri: Optional[str]
+    introspection_endpoint: Optional[str]
+    userinfo_endpoint: Optional[str]
+    algorithms: Iterable[str]
+
+
+class OIDCProvider:
+    """Interact with an OpenID Connect provider."""
+
+    def __init__(
+        self,
+        issuer: str,
+        *,
+        session: Optional[requests.Session] = None,
+        cache_ttl: int = 300,
+    ) -> None:
+        self.issuer = issuer.rstrip("/")
+        self._session = session or requests.Session()
+        self._cache_ttl = cache_ttl
+        self._metadata: Optional[ProviderMetadata] = None
+        self._metadata_expires_at = 0.0
+        self._jwks_cache: Optional[Dict[str, Any]] = None
+        self._jwks_expires_at = 0.0
+
+    def discover(self, *, force: bool = False) -> ProviderMetadata:
+        """Fetch the provider metadata using the discovery document."""
+
+        if not force and self._metadata and time.time() < self._metadata_expires_at:
+            return self._metadata
+
+        url = f"{self.issuer}/.well-known/openid-configuration"
+        response = self._session.get(url, timeout=5)
+        if response.status_code != 200:
+            raise DiscoveryError(f"Discovery failed with status {response.status_code}")
+
+        payload = response.json()
+        metadata = ProviderMetadata(
+            issuer=payload.get("issuer", self.issuer),
+            authorization_endpoint=payload.get("authorization_endpoint"),
+            token_endpoint=payload.get("token_endpoint"),
+            jwks_uri=payload.get("jwks_uri"),
+            introspection_endpoint=payload.get("introspection_endpoint"),
+            userinfo_endpoint=payload.get("userinfo_endpoint"),
+            algorithms=payload.get("id_token_signing_alg_values_supported", []),
+        )
+        self._metadata = metadata
+        self._metadata_expires_at = time.time() + self._cache_ttl
+        return metadata
+
+    def metadata(self) -> ProviderMetadata:
+        """Return cached metadata, performing discovery if needed."""
+
+        return self.discover()
+
+    def _get_jwks(self, *, force: bool = False) -> Dict[str, Any]:
+        metadata = self.metadata()
+        if not metadata.jwks_uri:
+            raise DiscoveryError("Provider metadata does not expose a jwks_uri")
+
+        if not force and self._jwks_cache and time.time() < self._jwks_expires_at:
+            return self._jwks_cache
+
+        response = self._session.get(metadata.jwks_uri, timeout=5)
+        if response.status_code != 200:
+            raise DiscoveryError("Failed to fetch JWKS")
+        data = response.json()
+        self._jwks_cache = data
+        self._jwks_expires_at = time.time() + self._cache_ttl
+        return data
+
+    def validate_token(
+        self,
+        token: str,
+        *,
+        audience: Optional[str] = None,
+        leeway: int = 0,
+        client_secret: Optional[str] = None,
+        require_signature: bool = True,
+    ) -> Dict[str, Any]:
+        """Validate an ID/access token against provider metadata."""
+
+        metadata = self.metadata()
+        header = jwt.get_unverified_header(token)
+        algorithm = header.get("alg")
+        options = {"require": ["exp", "iat"], "verify_aud": audience is not None}
+
+        try:
+            if algorithm and algorithm.startswith("HS"):
+                if not client_secret:
+                    raise TokenValidationError("client_secret required for HMAC tokens")
+                payload = jwt.decode(
+                    token,
+                    client_secret,
+                    algorithms=[algorithm] if algorithm else None,
+                    audience=audience,
+                    issuer=metadata.issuer,
+                    leeway=leeway,
+                    options=options,
+                )
+            else:
+                key = self._resolve_jwk_for_token(header)
+                if not require_signature and not key:
+                    decode_options = {"verify_signature": False, **options}
+                    payload = jwt.decode(
+                        token,
+                        None,
+                        audience=audience,
+                        issuer=metadata.issuer,
+                        leeway=leeway,
+                        options=decode_options,
+                    )
+                elif not key:
+                    raise TokenValidationError("Unable to resolve signing key for token")
+                else:
+                    public_key = _jwk_to_public_key(key)
+                    payload = jwt.decode(
+                        token,
+                        public_key,
+                        algorithms=[algorithm] if algorithm else None,
+                        audience=audience,
+                        issuer=metadata.issuer,
+                        leeway=leeway,
+                        options=options,
+                    )
+        except (InvalidTokenError, PyJWTError) as exc:
+            raise TokenValidationError(str(exc)) from exc
+
+        return payload
+
+    def _resolve_jwk_for_token(self, header: Mapping[str, Any]) -> Optional[Mapping[str, Any]]:
+        jwks = self._get_jwks()
+        keys = jwks.get("keys", []) if isinstance(jwks, Mapping) else []
+        kid = header.get("kid")
+        alg = header.get("alg")
+
+        for jwk in keys:
+            if kid and jwk.get("kid") != kid:
+                continue
+            if alg and jwk.get("alg") not in (None, alg):
+                continue
+            return jwk
+        return None
+
+
+def _jwk_to_public_key(jwk_dict: Mapping[str, Any]):
+    """Convert a JWK dictionary into a public key object for PyJWT."""
+
+    try:
+        from jwt.algorithms import RSAAlgorithm
+    except ImportError as exc:  # pragma: no cover - depends on optional dependency
+        raise TokenValidationError("RSA validation requires cryptography support") from exc
+
+    return RSAAlgorithm.from_jwk(json.dumps(jwk_dict))

--- a/src/security/signatures.py
+++ b/src/security/signatures.py
@@ -1,0 +1,175 @@
+"""Request signing utilities for inbound and outbound traffic."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import time
+from typing import Iterable, Mapping, Optional
+
+from flask import Flask, Request, request
+
+from ..utils.responses import error_response
+
+
+def _canonical_request(
+    req: Request,
+    *,
+    headers: Optional[Iterable[str]] = None,
+    timestamp: str,
+) -> bytes:
+    body_bytes = req.get_data(cache=True) or b""
+    if isinstance(body_bytes, str):
+        body_bytes = body_bytes.encode("utf-8")
+
+    hashed_body = hashlib.sha256(body_bytes).hexdigest()
+    header_values = []
+    if headers:
+        for header in headers:
+            value = req.headers.get(header, "")
+            header_values.append(f"{header.lower()}:{value.strip()}")
+    canonical = "\n".join(
+        [
+            req.method.upper(),
+            req.path,
+            hashed_body,
+            timestamp,
+            "\n".join(sorted(header_values)),
+        ]
+    )
+    return canonical.encode("utf-8")
+
+
+class RequestSigner:
+    """Sign outbound requests using shared HMAC secrets."""
+
+    def __init__(self, secret: str, *, algorithm: str = "sha256") -> None:
+        self.secret = secret.encode("utf-8")
+        self.algorithm = algorithm.lower()
+
+    def sign(
+        self,
+        req: Request,
+        *,
+        timestamp: Optional[str] = None,
+        headers: Optional[Iterable[str]] = None,
+    ) -> str:
+        timestamp = timestamp or str(int(time.time()))
+        canonical = _canonical_request(req, headers=headers, timestamp=timestamp)
+        digest = hmac.new(self.secret, canonical, self.algorithm).digest()
+        signature = base64.b64encode(digest).decode("ascii")
+        return signature
+
+
+class RequestSignatureMiddleware:
+    """Middleware validating signed requests using HMAC."""
+
+    def __init__(
+        self,
+        app: Flask,
+        secrets: Mapping[str, str],
+        *,
+        header_signature: str = "X-Signature",
+        header_timestamp: str = "X-Timestamp",
+        header_key_id: str = "X-Client-Id",
+        headers_to_include: Optional[Iterable[str]] = None,
+        algorithm: str = "sha256",
+        clock_tolerance: int = 300,
+        enabled: bool = True,
+        exempt_paths: Optional[Iterable[str]] = None,
+    ) -> None:
+        self.app = app
+        self.secrets = {key_id: value.encode("utf-8") for key_id, value in secrets.items()}
+        self.header_signature = header_signature
+        self.header_timestamp = header_timestamp
+        self.header_key_id = header_key_id
+        self.headers_to_include = tuple(headers_to_include or ())
+        self.algorithm = algorithm.lower()
+        self.clock_tolerance = clock_tolerance
+        self.enabled = enabled and bool(self.secrets)
+        self.exempt_paths = tuple(exempt_paths or ("/health",))
+        if self.enabled:
+            app.before_request(self._verify_signature)
+
+    def _is_exempt(self, req: Request) -> bool:
+        path = req.path or "/"
+        return any(path.startswith(prefix) for prefix in self.exempt_paths)
+
+    def _verify_signature(self):
+        if not self.enabled:
+            return None
+        if self._is_exempt(request):
+            return None
+
+        key_id = request.headers.get(self.header_key_id)
+        signature = request.headers.get(self.header_signature)
+        timestamp = request.headers.get(self.header_timestamp)
+
+        if not key_id or not signature or not timestamp:
+            return error_response(401, "Signed request headers missing")
+
+        secret = self.secrets.get(key_id)
+        if not secret:
+            return error_response(403, "Unknown signing key")
+
+        if not self._is_timestamp_valid(timestamp):
+            return error_response(401, "Expired signature")
+
+        canonical = _canonical_request(request, headers=self.headers_to_include, timestamp=timestamp)
+        expected = base64.b64encode(
+            hmac.new(secret, canonical, self.algorithm).digest()
+        ).decode("ascii")
+
+        if not hmac.compare_digest(expected, signature):
+            return error_response(403, "Invalid signature")
+
+        return None
+
+    def _is_timestamp_valid(self, timestamp: str) -> bool:
+        try:
+            ts = int(timestamp)
+        except ValueError:
+            return False
+        now = int(time.time())
+        return abs(now - ts) <= self.clock_tolerance
+
+
+def configure_request_signatures(app: Flask) -> Optional[RequestSignatureMiddleware]:
+    """Configure request signature verification middleware."""
+
+    secrets_raw = app.config.get("SIGNING_SECRETS", "")
+    secrets = {}
+    for token in [part.strip() for part in secrets_raw.split(",") if part.strip()]:
+        if ":" not in token:
+            continue
+        key_id, secret = token.split(":", 1)
+        if key_id and secret:
+            secrets[key_id.strip()] = secret.strip()
+
+    enabled = app.config.get("REQUEST_SIGNATURES_ENABLED", bool(secrets))
+    header_signature = app.config.get("SIGNATURE_HEADER", "X-Signature")
+    header_timestamp = app.config.get("SIGNATURE_TIMESTAMP_HEADER", "X-Timestamp")
+    header_key_id = app.config.get("SIGNATURE_KEY_ID_HEADER", "X-Client-Id")
+    algorithm = app.config.get("SIGNATURE_ALGORITHM", "sha256")
+    clock_tolerance = int(app.config.get("SIGNATURE_CLOCK_TOLERANCE", 300))
+    headers_to_include = app.config.get("SIGNATURE_HEADERS", [])
+    exempt_paths = app.config.get("SIGNATURE_EXEMPT_PATHS", ("/health",))
+
+    if not enabled or not secrets:
+        app.logger.info("Request signature middleware disabled")
+        return None
+
+    middleware = RequestSignatureMiddleware(
+        app,
+        secrets,
+        header_signature=header_signature,
+        header_timestamp=header_timestamp,
+        header_key_id=header_key_id,
+        headers_to_include=headers_to_include,
+        algorithm=algorithm,
+        clock_tolerance=clock_tolerance,
+        exempt_paths=exempt_paths,
+    )
+    app.extensions["request_signature_middleware"] = middleware
+    return middleware

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,176 @@
+"""Tests for security components."""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict
+
+import jwt
+import pytest
+from flask import Flask, Request
+from werkzeug.test import EnvironBuilder
+
+from src.app import _configure_ip_filters
+from src.security.api_keys import APIKeyMiddleware, APIKeyStore
+from src.security.oauth import OIDCProvider, ProviderMetadata, TokenValidationError
+from src.security.signatures import RequestSignatureMiddleware, RequestSigner
+
+
+class DummyResponse:
+    def __init__(self, status_code: int, payload: Dict[str, Any]):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class DummySession:
+    def __init__(self, metadata: Dict[str, Any]):
+        self.metadata = metadata
+        self.calls: list[str] = []
+
+    def get(self, url: str, timeout: int):  # noqa: D401 - simple stub
+        self.calls.append(url)
+        if url.endswith("/.well-known/openid-configuration"):
+            return DummyResponse(200, self.metadata)
+        raise AssertionError(f"Unexpected URL {url}")
+
+
+def build_request(
+    method: str,
+    path: str,
+    data: bytes | str = b"",
+    headers: Dict[str, str] | None = None,
+) -> Request:
+    builder = EnvironBuilder(method=method, path=path, data=data, headers=headers or {})
+    env = builder.get_environ()
+    return Request(env)
+
+
+def test_api_key_middleware_enforces_keys():
+    app = Flask(__name__)
+    store = APIKeyStore(keys={"client": "topsecret"})
+    APIKeyMiddleware(app, store, exempt_paths=())
+
+    @app.route("/protected")
+    def protected():
+        return "ok"
+
+    client = app.test_client()
+
+    missing = client.get("/protected")
+    assert missing.status_code == 401
+
+    invalid = client.get("/protected", headers={"X-API-Key": "wrong"})
+    assert invalid.status_code == 403
+
+    valid = client.get("/protected", headers={"X-API-Key": "topsecret"})
+    assert valid.status_code == 200
+
+
+def test_oidc_provider_discovers_and_validates_hs256():
+    metadata = {
+        "issuer": "https://id.example.com",
+        "authorization_endpoint": "https://id.example.com/auth",
+        "token_endpoint": "https://id.example.com/token",
+        "jwks_uri": "https://id.example.com/jwks",
+        "id_token_signing_alg_values_supported": ["HS256"],
+    }
+    session = DummySession(metadata)
+    provider = OIDCProvider(metadata["issuer"], session=session)
+
+    discovered = provider.discover(force=True)
+    assert isinstance(discovered, ProviderMetadata)
+    assert discovered.issuer == metadata["issuer"]
+
+    now = int(time.time())
+    payload = {
+        "sub": "123",
+        "aud": "api-gateway",
+        "iss": metadata["issuer"],
+        "exp": now + 300,
+        "iat": now,
+    }
+    token = jwt.encode(payload, "shared-secret", algorithm="HS256")
+
+    validated = provider.validate_token(
+        token,
+        audience="api-gateway",
+        client_secret="shared-secret",
+    )
+    assert validated["sub"] == "123"
+
+    with pytest.raises(TokenValidationError):
+        provider.validate_token(token, audience="api-gateway", client_secret="wrong")
+
+
+def test_request_signature_middleware_validates_hmac():
+    app = Flask(__name__)
+    RequestSignatureMiddleware(
+        app,
+        {"client": "sig-secret"},
+        headers_to_include=["X-Test"],
+        exempt_paths=(),
+    )
+
+    @app.route("/signed", methods=["POST"])
+    def signed():
+        return "signed"
+
+    timestamp = str(int(time.time()))
+    outbound_request = build_request(
+        "POST",
+        "/signed",
+        data=b"payload",
+        headers={"X-Test": "value", "X-Client-Id": "client"},
+    )
+    signer = RequestSigner("sig-secret")
+    signature = signer.sign(outbound_request, timestamp=timestamp, headers=["X-Test"])
+
+    client = app.test_client()
+    ok = client.post(
+        "/signed",
+        data=b"payload",
+        headers={
+            "X-Test": "value",
+            "X-Client-Id": "client",
+            "X-Timestamp": timestamp,
+            "X-Signature": signature,
+        },
+    )
+    assert ok.status_code == 200
+
+    tampered = client.post(
+        "/signed",
+        data=b"payload",
+        headers={
+            "X-Test": "value",
+            "X-Client-Id": "client",
+            "X-Timestamp": timestamp,
+            "X-Signature": "bad",
+        },
+    )
+    assert tampered.status_code == 403
+
+
+def test_ip_filtering_blocks_blacklisted_addresses():
+    app = Flask(__name__)
+    app.config["IP_WHITELIST"] = {"127.0.0.1"}
+    app.config["IP_BLACKLIST"] = {"10.0.0.1"}
+    _configure_ip_filters(app)
+
+    @app.route("/ping")
+    def ping():
+        return "pong"
+
+    client = app.test_client()
+
+    allowed = client.get("/ping")
+    assert allowed.status_code == 200
+
+    blocked = client.get("/ping", environ_overrides={"REMOTE_ADDR": "10.0.0.1"})
+    assert blocked.status_code == 403
+
+    denied = client.get("/ping", environ_overrides={"REMOTE_ADDR": "192.168.0.20"})
+    assert denied.status_code == 403


### PR DESCRIPTION
## Summary
- add reusable security package with API key storage/middleware, OIDC provider and HMAC request signatures
- extend app configuration for API key enforcement, IP filtering, signature verification and OAuth provider caching
- document security options and add regression tests covering API keys, OIDC discovery/validation, signatures and IP policies

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d995f9c6c083329acea2ccbe762ecc