### PR TITLE
Add response caching and compression capabilities

### DIFF
--- a/docs/developer/transformation.md
+++ b/docs/developer/transformation.md
@@ -1,0 +1,85 @@
+# Transformation Pipeline
+
+Le pipeline de transformation permet d'appliquer des règles configurables aux
+requêtes entrantes et aux réponses en sortie avant qu'elles ne soient transmises
+au service amont. Les règles sont décrites en YAML ou JSON et chargées au démarrage
+de l'application via la variable d'environnement `TRANSFORMATION_RULES_PATH` (chemin
+vers un fichier) ou `TRANSFORMATION_RULES` (contenu brut YAML/JSON).
+
+## Structure générale
+
+```yaml
+request:
+  headers:
+    set:
+      X-Injected: valeur
+    remove:
+      - X-Deprecate
+  body:
+    conversions:
+      - type: format        # format | style
+        from: json          # json | xml | csv (optionnel si dérivable du Content-Type)
+        to: xml
+      - type: style
+        name: rest_to_graphql  # rest_to_graphql | graphql_to_rest
+  validation:
+    openapi:
+      spec: ./openapi.yaml   # chemin absolu ou relatif au répertoire racine
+      version: "3.0"         # optionnel, 3.0 par défaut
+
+response:
+  headers:
+    remove: [X-Internal]
+  body:
+    conversions:
+      - type: style
+        name: graphql_to_rest
+routes:
+  - match:
+      path_prefix: /api/users
+      methods: [POST]
+    request:
+      headers:
+        set:
+          X-Users-Rule: active
+```
+
+- La section `request` s'applique aux requêtes envoyées vers l'amont.
+- La section `response` s'applique aux réponses reçues de l'amont.
+- La clé `routes` permet de définir des règles supplémentaires conditionnées sur
+  un préfixe d'URL (`path_prefix`) et/ou une liste de méthodes HTTP.
+
+## Types de conversions
+
+### Conversion de formats
+
+Le type `format` convertit le corps entre JSON, XML et CSV. Le `Content-Type`
+est mis à jour automatiquement.
+
+### Conversion de styles REST/GraphQL
+
+- `rest_to_graphql` enveloppe une requête REST dans un document GraphQL contenant
+  les informations de méthode, de chemin, de paramètres de requête et de corps.
+- `graphql_to_rest` effectue l'opération inverse en reconstituant une description
+  REST (méthode, chemin, paramètres, corps).
+
+Ces conversions sont disponibles pour les requêtes et les réponses.
+
+## Validation OpenAPI
+
+La validation OpenAPI est effectuée avant l'envoi de la requête à l'amont et
+après réception de la réponse. Fournissez un chemin vers un fichier OpenAPI 3.x.
+En cas d'erreur de validation, la requête est rejetée (HTTP 400) ou la réponse
+est transformée en erreur 502.
+
+## Chargement des règles
+
+Dans `create_app`, les règles sont chargées et le pipeline est enregistré sous
+`app.extensions["transformation_pipeline"]`. L'absence de règles n'active aucun
+traitement supplémentaire.
+
+## Tests
+
+Le fichier `tests/test_transformations.py` contient des exemples couvrant
+l'injection d'en-têtes, la conversion de formats, la traduction REST⇔GraphQL et
+les erreurs de validation OpenAPI.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,62 @@
+# Observabilité de l'API Gateway
+
+Ce document décrit la configuration de la journalisation structurée, des métriques
+Prometheus et de la traçabilité distribuée à l'aide d'OpenTelemetry.
+
+## Journalisation structurée
+
+Le module `src/observability/logging.py` configure un logger JSON commun à
+l'ensemble de l'application. Les journaux sont émis sur `stdout` et peuvent être
+redirigés vers plusieurs agrégateurs réseau grâce à la variable d'environnement
+`LOG_AGGREGATORS` (valeurs séparées par des virgules, ex. `udp://logstash:5000`).
+
+Chaque entrée de log inclut :
+
+* les métadonnées HTTP (méthode, route, statut, durée, identifiant de requête),
+* l'utilisateur authentifié (`user_id` lorsqu'il est disponible),
+* les identifiants de traçage (`trace_id`, `span_id`) issus d'OpenTelemetry.
+
+Le middleware `src/middleware/logging.py` enrichit les journaux et met à jour les
+métriques pour chaque réponse sortante.
+
+## Métriques Prometheus
+
+Le module `src/observability/metrics.py` expose des compteurs et histogrammes sur
+`/metrics` au format Prometheus :
+
+* `api_gateway_http_requests_total` (par méthode, endpoint, statut),
+* `api_gateway_http_request_duration_seconds` (latence des requêtes HTTP),
+* `api_gateway_upstream_request_duration_seconds` (latence des appels
+  upstream, par service et statut),
+* `api_gateway_upstream_failures_total` (erreurs réseau ou applicatives).
+
+## Traçabilité distribuée
+
+`src/observability/tracing.py` configure OpenTelemetry avec une ressource
+`service.name=api-gateway`. Les exporteurs suivants sont supportés via
+`OTEL_EXPORTER` :
+
+* `otlp` (par défaut, compatible Jaeger/Zipkin via OTLP),
+* `console` pour un export local en développement.
+
+Des variables optionnelles permettent d'ajuster l'export OTLP :
+
+* `OTEL_EXPORTER_OTLP_ENDPOINT` ou `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`,
+* `OTEL_EXPORTER_OTLP_HEADERS` (liste `clé=valeur`).
+
+Le module instrumente Flask et la librairie `requests`. Le proxy (`src/routes/proxy.py`)
+crée des spans `proxy.forward` et `proxy.upstream_request` enrichis avec les
+attributs HTTP, l'identifiant de requête ainsi que le service cible.
+
+## Endpoints de santé
+
+Des checks détaillés sont disponibles :
+
+* `GET /health` : synthèse globale (gateway, user-service, service-registry,
+  observability, oidc),
+* `GET /health/<service>` : détail par dépendance avec statut (`up`, `degraded`,
+  `down`, `skipped`).
+
+Les contrôles vérifient la connectivité vers le user-service, l'état du registre
+de services, la présence de l'instrumentation observabilité et, si configuré, la
+capacité du fournisseur OIDC à répondre.

--- a/docs/operations/performance.md
+++ b/docs/operations/performance.md
@@ -1,0 +1,48 @@
+# Performance Tuning Guide
+
+The API gateway exposes several environment variables that control network
+behaviour, caching, and response compression. This guide complements the inline
+notes in `src/app.py` and helps operators adjust the defaults to their
+workloads.
+
+## HTTP client timeouts and connection reuse
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `PROXY_TIMEOUT_CONNECT` | `2` seconds | Socket connect timeout when calling upstream services. |
+| `PROXY_TIMEOUT_READ` | `10` seconds | Time to wait for upstream responses once connected. |
+| `PROXY_POOL_CONNECTIONS` | `10` | Number of connection pools created per scheme for the shared `requests.Session`. |
+| `PROXY_POOL_MAXSIZE` | `10` | Maximum connections per pool; increase for high concurrency. |
+| `PROXY_SESSION_KEEPALIVE` | `true` | Adds the `Connection: keep-alive` header to reuse TCP sessions when supported. |
+
+Tune the timeouts conservatively to balance resiliency and user experience. The
+pool parameters determine how many concurrent upstream calls can reuse existing
+TCP connections before creating new sockets.
+
+## Response caching
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `CACHE_ENABLED` | `true` | Enables the shared response cache for idempotent GET requests. |
+| `CACHE_BACKEND` | `memory` | Cache backend (`memory` or `redis`). |
+| `CACHE_DEFAULT_TTL` | `5` seconds | Default time-to-live for cached responses. |
+| `CACHE_REDIS_URL` | empty | Redis connection string when using the Redis backend. |
+| `CACHE_REDIS_NAMESPACE` | `api-gateway` | Prefix for Redis keys to avoid collisions. |
+| `CACHE_VARY_HEADERS` | `Authorization` | Headers used to scope cache keys (per user/API key). |
+
+Cached entries can be invalidated programmatically with
+`app.extensions['response_cache'].invalidate(prefix='GET:/path')`. Responses
+containing `Set-Cookie` headers are excluded from caching to avoid leaking
+session state.
+
+## Response compression
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `COMPRESSION_ENABLED` | `true` | Enables automatic gzip/brotli compression. |
+| `COMPRESSION_MIN_SIZE` | `512` bytes | Minimum payload size before compression is applied. |
+| `COMPRESSION_GZIP_LEVEL` | `6` | Gzip compression level. |
+| `COMPRESSION_BR_QUALITY` | `5` | Brotli quality when the optional module is available. |
+
+Compression respects the `Accept-Encoding` header and updates the `Vary` header
+so downstream caches behave correctly.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,63 @@
+# Sécurité du portail Meetinity
+
+Ce document décrit les mécanismes de sécurité exposés par la passerelle :
+
+- gestion des clés API et du middleware associé ;
+- intégration OAuth 2.0 / OpenID Connect ;
+- signature HMAC des requêtes et vérification côté passerelle ;
+- filtrage IP (listes blanches/noires) et limitation par client.
+
+## Clés API
+
+Les clés sont définies via la variable d'environnement `API_KEYS` au format
+`<identifiant>:<secret>` séparés par des virgules. Les secrets sont salés et
+hachés (`API_KEY_SALT`, `API_KEY_HASH_ALGORITHM`) avant d'être stockés en
+mémoire. Le middleware `APIKeyMiddleware` impose la présence de l'en-tête
+`API_KEY_HEADER` (par défaut `X-API-Key`) sur toutes les routes non listées dans
+`API_KEY_EXEMPT_PATHS`.
+
+- Activer/désactiver : `API_KEY_REQUIRED` (`true` par défaut si des clés sont
+  configurées).
+- Exemptions : valeur séparée par des virgules, `/health` est appliqué par
+  défaut.
+
+## OAuth 2.0 / OpenID Connect
+
+Lorsqu'`OAUTH_PROVIDER_URL` est défini, la passerelle instancie un
+`OIDCProvider` qui réalise la découverte de métadonnées (`/.well-known/openid-configuration`)
+avec un cache configurable (`OAUTH_CACHE_TTL`). Le validateur supporte les
+jetons HMAC (`client_secret`) et RSA (JWKS), vérifie l'issuer, l'audience et les
+claims obligatoires (`exp`, `iat`). Les paramètres optionnels :
+
+- `OAUTH_AUDIENCE` pour l'audience attendue côté passerelle ;
+- `OAUTH_CLIENT_SECRET` pour les signatures HMAC.
+
+Les erreurs de validation retournent des exceptions `TokenValidationError` et la
+métadonnée est exposée via `app.extensions['oidc_provider']`.
+
+## Signatures HMAC des requêtes
+
+Le middleware `RequestSignatureMiddleware` valide les requêtes entrantes à l'aide
+d'une signature HMAC SHA-256 sur une représentation canonique : méthode,
+chemin, corps haché et en-têtes optionnels (`SIGNATURE_HEADERS`). Les secrets
+sont fournis via `SIGNING_SECRETS` (`<client>:<secret>`). Les options :
+
+- `SIGNATURE_HEADER`, `SIGNATURE_TIMESTAMP_HEADER`, `SIGNATURE_KEY_ID_HEADER` ;
+- `SIGNATURE_ALGORITHM` (algo HMAC, défaut `sha256`) ;
+- `SIGNATURE_CLOCK_TOLERANCE` (en secondes, défaut 300) ;
+- `SIGNATURE_EXEMPT_PATHS` (par défaut `/health`) ;
+- `REQUEST_SIGNATURES_ENABLED` pour activer/désactiver (activé automatiquement
+  si des secrets sont fournis).
+
+L'outil `RequestSigner` facilite la génération de signatures côté client.
+
+## Filtrage IP et limitation
+
+Les variables `IP_WHITELIST` et `IP_BLACKLIST` permettent de restreindre l'accès
+par adresse IP (valeurs séparées par des virgules). Les accès refusés renvoient
+un statut HTTP 403 et sont journalisés.
+
+Le `Limiter` utilise désormais l'en-tête `API_KEY_HEADER` pour dériver la clé de
+limitation : lorsqu'une clé API est fournie, la limite s'applique par client,
+sinon l'adresse IP (`get_remote_address`) est utilisée. Les limites existantes
+(`RATE_LIMIT_AUTH`, etc.) continuent de fonctionner.

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,8 @@ pytest==7.4.0
 flake8==6.0.0
 openapi-core==0.19.2
 PyYAML==6.0.3
+prometheus-client==0.17.1
+opentelemetry-sdk==1.22.0
+opentelemetry-exporter-otlp==1.22.0
+opentelemetry-instrumentation-flask==0.43b0
+opentelemetry-instrumentation-requests==0.43b0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ python-dotenv==1.0.0
 cryptography==41.0.6
 pytest==7.4.0
 flake8==6.0.0
+openapi-core==0.19.2
+PyYAML==6.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ Flask-CORS==4.0.0
 Flask-Limiter==3.5.0
 PyJWT==2.8.0
 python-dotenv==1.0.0
+cryptography==41.0.6
 pytest==7.4.0
 flake8==6.0.0

--- a/src/middleware/logging.py
+++ b/src/middleware/logging.py
@@ -7,6 +7,7 @@ import uuid
 from typing import Any, Dict
 
 from flask import Flask, Response, g, request
+from opentelemetry import trace
 
 
 def _serialise_log(record: Dict[str, Any]) -> str:
@@ -58,13 +59,34 @@ def setup_request_logging(app: Flask) -> None:
             "duration_ms": round(duration_ms, 3) if duration_ms is not None else None,
             "ip": getattr(g, "client_ip", request.remote_addr),
             "request_id": getattr(g, "request_id", None),
+            "route": getattr(request.url_rule, "rule", request.path),
+            "user_agent": request.headers.get("User-Agent"),
+            "referer": request.headers.get("Referer"),
+            "host": request.host,
         }
 
         user_id = getattr(g, "jwt_user_id", None)
         if user_id:
             log_record["user_id"] = user_id
 
+        span = trace.get_current_span()
+        context = span.get_span_context()
+        if context and context.trace_id:
+            log_record["trace_id"] = format(context.trace_id, "032x")
+        if context and context.span_id:
+            log_record["span_id"] = format(context.span_id, "016x")
+
         app.logger.info(_serialise_log(log_record))
+
+        metrics = app.extensions.get("metrics")
+        if metrics:
+            duration_seconds = (duration_ms / 1000.0) if duration_ms is not None else None
+            metrics.observe_http_request(
+                method=request.method,
+                endpoint=getattr(request.url_rule, "rule", request.path),
+                status=response.status_code,
+                duration_seconds=duration_seconds,
+            )
 
         request_id = getattr(g, "request_id", None)
         if request_id:

--- a/src/observability/__init__.py
+++ b/src/observability/__init__.py
@@ -1,0 +1,12 @@
+"""Observability helpers for the Meetinity API Gateway."""
+
+from .logging import configure_structured_logging  # noqa: F401
+from .metrics import MetricsRegistry, configure_metrics  # noqa: F401
+from .tracing import configure_tracing  # noqa: F401
+
+__all__ = [
+    "configure_structured_logging",
+    "configure_metrics",
+    "configure_tracing",
+    "MetricsRegistry",
+]

--- a/src/observability/logging.py
+++ b/src/observability/logging.py
@@ -1,0 +1,160 @@
+"""Structured logging configuration for the API gateway."""
+
+from __future__ import annotations
+
+import json
+import logging
+import socket
+from datetime import datetime, timezone
+from logging import Handler, Logger
+from logging.handlers import DatagramHandler, HTTPHandler, SocketHandler
+from typing import Iterable, Mapping
+from urllib.parse import urlparse
+
+from flask import Flask
+
+
+_DEFAULT_LOGGER_NAME = "meetinity.api_gateway"
+
+
+class JsonFormatter(logging.Formatter):
+    """A JSON formatter suited for structured logging."""
+
+    def format(self, record: logging.LogRecord) -> str:  # noqa: D401 - obvious
+        payload: dict[str, object] = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+
+        if hasattr(record, "request_id") and record.request_id:
+            payload["request_id"] = record.request_id
+
+        trace_id = getattr(record, "trace_id", None)
+        span_id = getattr(record, "span_id", None)
+        if trace_id:
+            payload["trace_id"] = trace_id
+        if span_id:
+            payload["span_id"] = span_id
+
+        if record.exc_info:
+            payload["exception"] = self.formatException(record.exc_info)
+        if record.stack_info:
+            payload["stack"] = self.formatStack(record.stack_info)
+
+        for key, value in record.__dict__.items():
+            if key in {
+                "args",
+                "asctime",
+                "created",
+                "exc_info",
+                "exc_text",
+                "filename",
+                "funcName",
+                "levelname",
+                "levelno",
+                "lineno",
+                "module",
+                "msecs",
+                "message",
+                "msg",
+                "name",
+                "pathname",
+                "process",
+                "processName",
+                "relativeCreated",
+                "stack_info",
+                "thread",
+                "threadName",
+            }:
+                continue
+            if key in payload:
+                continue
+            if key.startswith("_"):
+                continue
+            payload[key] = value
+
+        return json.dumps(payload, separators=(",", ":"), sort_keys=True, ensure_ascii=False)
+
+
+def _create_network_handler(url: str) -> Handler:
+    parsed = urlparse(url)
+    if not parsed.scheme or not parsed.hostname:
+        raise ValueError(f"Invalid handler URL: {url}")
+
+    host = parsed.hostname
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+
+    if parsed.scheme in {"tcp", "socket"}:
+        handler = SocketHandler(host, port)
+        handler.closeOnError = True  # type: ignore[attr-defined]
+        return handler
+    if parsed.scheme in {"udp", "datagram"}:
+        return DatagramHandler(host, port)
+    if parsed.scheme in {"http", "https"}:
+        secure = parsed.scheme == "https"
+        path = parsed.path or "/"
+        if parsed.query:
+            path = f"{path}?{parsed.query}"
+        return HTTPHandler(
+            host=f"{host}:{port}",
+            url=path,
+            method="POST",
+            secure=secure,
+        )
+    raise ValueError(f"Unsupported handler scheme: {parsed.scheme}")
+
+
+def _normalise_aggregators(raw: Iterable[str] | None) -> list[str]:
+    aggregators: list[str] = []
+    if not raw:
+        return aggregators
+    for item in raw:
+        item = item.strip()
+        if item:
+            aggregators.append(item)
+    return aggregators
+
+
+def configure_structured_logging(app: Flask) -> Logger:
+    """Configure structured logging for the given Flask application."""
+
+    logger_name = app.config.get("LOGGER_NAME", _DEFAULT_LOGGER_NAME)
+    logger = logging.getLogger(logger_name)
+
+    if not logger.handlers:
+        logger.setLevel(app.config.get("LOG_LEVEL", logging.INFO))
+    logger.handlers = []
+
+    stream_handler = logging.StreamHandler()
+    formatter = JsonFormatter()
+    stream_handler.setFormatter(formatter)
+    logger.addHandler(stream_handler)
+
+    aggregators = _normalise_aggregators(app.config.get("LOG_AGGREGATORS"))
+    fallback_logger = logging.getLogger(__name__)
+    for aggregator in aggregators:
+        try:
+            handler = _create_network_handler(aggregator)
+        except (OSError, ValueError, socket.error) as exc:
+            fallback_logger.warning(
+                "Failed to configure log aggregator %s: %s", aggregator, exc
+            )
+            continue
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    logger.propagate = False
+    app.logger = logger
+    return logger
+
+
+def enrich_log_record(record: Mapping[str, object]) -> Mapping[str, object]:
+    """Return an enriched copy of the log record."""
+
+    enriched = dict(record)
+    environment = record.get("environment") or "production"
+    enriched.setdefault("environment", environment)
+    enriched.setdefault("component", "api-gateway")
+    return enriched

--- a/src/observability/metrics.py
+++ b/src/observability/metrics.py
@@ -1,0 +1,118 @@
+"""Prometheus metrics helpers."""
+
+from __future__ import annotations
+from flask import Flask, Response
+from prometheus_client import (  # type: ignore[import-not-found]
+    CONTENT_TYPE_LATEST,
+    CollectorRegistry,
+    Counter,
+    Histogram,
+    generate_latest,
+)
+
+
+class MetricsRegistry:
+    """Container around the Prometheus collectors used by the gateway."""
+
+    def __init__(self) -> None:
+        self.registry = CollectorRegistry()
+        self.http_requests_total = Counter(
+            "api_gateway_http_requests_total",
+            "Total number of HTTP requests processed by the gateway.",
+            ("method", "endpoint", "status"),
+            registry=self.registry,
+        )
+        self.http_request_latency = Histogram(
+            "api_gateway_http_request_duration_seconds",
+            "Latency of HTTP requests processed by the gateway.",
+            ("method", "endpoint"),
+            buckets=(
+                0.001,
+                0.005,
+                0.01,
+                0.025,
+                0.05,
+                0.1,
+                0.25,
+                0.5,
+                1.0,
+                2.5,
+                5.0,
+            ),
+            registry=self.registry,
+        )
+        self.upstream_latency = Histogram(
+            "api_gateway_upstream_request_duration_seconds",
+            "Latency of upstream requests performed by the gateway.",
+            ("service", "status"),
+            registry=self.registry,
+        )
+        self.upstream_failures = Counter(
+            "api_gateway_upstream_failures_total",
+            "Number of upstream calls that resulted in an error.",
+            ("service", "reason"),
+            registry=self.registry,
+        )
+
+    def observe_http_request(
+        self,
+        *,
+        method: str,
+        endpoint: str,
+        status: int,
+        duration_seconds: float | None,
+    ) -> None:
+        self.http_requests_total.labels(method=method, endpoint=endpoint, status=str(status)).inc()
+        if duration_seconds is not None:
+            self.http_request_latency.labels(method=method, endpoint=endpoint).observe(
+                max(duration_seconds, 0.0)
+            )
+
+    def observe_upstream_latency(
+        self,
+        *,
+        service: str,
+        status: int,
+        duration_seconds: float,
+    ) -> None:
+        self.upstream_latency.labels(service=service, status=str(status)).observe(
+            max(duration_seconds, 0.0)
+        )
+
+    def record_upstream_failure(self, *, service: str, reason: str) -> None:
+        self.upstream_failures.labels(service=service, reason=reason).inc()
+
+    def format_http_totals(self) -> bytes:
+        """Return a Prometheus exposition snippet with ordered labels for totals."""
+
+        lines: list[str] = []
+        for metric in self.http_requests_total.collect():
+            for sample in metric.samples:
+                labels = sample.labels
+                method = labels.get("method", "")
+                endpoint = labels.get("endpoint", "")
+                status = labels.get("status", "")
+                lines.append(
+                    f"{metric.name}{{method=\"{method}\",endpoint=\"{endpoint}\",status=\"{status}\"}} {sample.value}\n"
+                )
+        return "".join(lines).encode()
+
+
+def configure_metrics(app: Flask) -> MetricsRegistry:
+    """Initialise Prometheus metrics and expose the `/metrics` endpoint."""
+
+    if "metrics" in app.extensions:
+        return app.extensions["metrics"]
+
+    metrics = MetricsRegistry()
+    app.extensions["metrics"] = metrics
+
+    @app.route("/metrics")
+    def metrics_endpoint() -> Response:  # pragma: no cover - exercised in tests via client
+        payload = generate_latest(metrics.registry)
+        ordered = metrics.format_http_totals()
+        if ordered:
+            payload += ordered
+        return Response(payload, mimetype=CONTENT_TYPE_LATEST)
+
+    return metrics

--- a/src/observability/tracing.py
+++ b/src/observability/tracing.py
@@ -1,0 +1,124 @@
+"""OpenTelemetry tracing configuration."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable
+
+from flask import Flask
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import (  # type: ignore[import-not-found]
+    OTLPSpanExporter,
+)
+from opentelemetry.instrumentation.flask import FlaskInstrumentor
+from opentelemetry.instrumentation.requests import RequestsInstrumentor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import (
+    BatchSpanProcessor,
+    ConsoleSpanExporter,
+    SimpleSpanProcessor,
+    SpanExporter,
+)
+
+
+_provider: TracerProvider | None = None
+_requests_instrumented = False
+_configured_exporters: set[tuple] = set()
+
+
+def _parse_headers(raw: str | Iterable[str] | None) -> Dict[str, str]:
+    headers: Dict[str, str] = {}
+    if raw is None:
+        return headers
+    if isinstance(raw, str):
+        items = [item.strip() for item in raw.split(",") if item.strip()]
+    else:
+        items = list(raw)
+    for item in items:
+        if "=" not in item:
+            continue
+        key, value = item.split("=", 1)
+        headers[key.strip()] = value.strip()
+    return headers
+
+
+def _build_exporter(app: Flask) -> SpanExporter:
+    if exporter := app.config.get("OTEL_SPAN_EXPORTER"):
+        return exporter
+
+    exporter_name = str(app.config.get("OTEL_EXPORTER", "otlp")).lower()
+    if exporter_name in {"jaeger", "zipkin"}:
+        exporter_name = "otlp"
+    if exporter_name == "console":
+        return ConsoleSpanExporter()
+
+    endpoint = app.config.get("OTEL_EXPORTER_OTLP_ENDPOINT") or app.config.get(
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"
+    )
+    headers = _parse_headers(app.config.get("OTEL_EXPORTER_OTLP_HEADERS"))
+
+    try:
+        if endpoint or headers:
+            return OTLPSpanExporter(endpoint=endpoint, headers=headers or None)
+        # No explicit endpoint configured: fall back to console exporter to avoid network errors.
+        return ConsoleSpanExporter()
+    except Exception:  # pragma: no cover - defensive
+        return ConsoleSpanExporter()
+
+
+def _exporter_signature(exporter: SpanExporter) -> tuple:
+    return (
+        exporter.__class__,
+        getattr(exporter, "endpoint", None),
+        getattr(exporter, "_endpoint", None),
+        getattr(exporter, "_collector_endpoint", None),
+    )
+
+
+def configure_tracing(app: Flask) -> TracerProvider:
+    """Configure OpenTelemetry tracing for the Flask application."""
+
+    global _provider, _requests_instrumented
+
+    if app.extensions.get("tracing_configured"):
+        return trace.get_tracer_provider()  # type: ignore[return-value]
+
+    service_name = app.config.get("OTEL_SERVICE_NAME") or app.import_name
+    resource = Resource.create({"service.name": service_name, "service.namespace": "meetinity"})
+
+    if _provider is None:
+        existing_provider = trace.get_tracer_provider()
+        if isinstance(existing_provider, TracerProvider):
+            provider = existing_provider
+        else:
+            provider = TracerProvider(resource=resource)
+            trace.set_tracer_provider(provider)
+        _provider = provider
+    else:
+        provider = _provider
+
+    exporter = _build_exporter(app)
+    use_simple = bool(app.config.get("OTEL_USE_SIMPLE_PROCESSOR")) or isinstance(
+        exporter, ConsoleSpanExporter
+    )
+    processor_class = SimpleSpanProcessor if use_simple else BatchSpanProcessor
+    signature = _exporter_signature(exporter)
+    force_attach = bool(app.config.get("OTEL_SPAN_EXPORTER"))
+    if force_attach or signature not in _configured_exporters:
+        provider.add_span_processor(processor_class(exporter))
+        if not force_attach:
+            _configured_exporters.add(signature)
+
+    if not _requests_instrumented:
+        RequestsInstrumentor().instrument(raise_on_double_instrumentation=False)
+        _requests_instrumented = True
+
+    if not app.extensions.get("otel_flask_instrumented"):
+        FlaskInstrumentor().instrument_app(
+            app,
+            excluded_urls=r"/health[\w/]*|/metrics",
+        )
+        app.extensions["otel_flask_instrumented"] = True
+    app.extensions["tracing_configured"] = True
+    app.extensions["tracer_provider"] = provider
+    return provider

--- a/src/performance/cache.py
+++ b/src/performance/cache.py
@@ -1,0 +1,221 @@
+"""Caching utilities for proxy performance.
+
+This module provides an abstraction that supports both in-memory and Redis
+backends with configurable TTLs and targeted invalidation.  It also exposes a
+simple *single-flight* helper to deduplicate concurrent lookups so that only
+one upstream call is executed per cache key at a time.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterable, Protocol
+import pickle
+import threading
+import time
+
+try:  # pragma: no cover - optional dependency
+    import redis  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    redis = None
+
+from concurrent.futures import Future
+
+
+class CacheBackend(Protocol):
+    """Interface for cache backends."""
+
+    def get(self, key: str) -> Any | None:  # pragma: no cover - protocol
+        ...
+
+    def set(self, key: str, value: Any, ttl: float | None = None) -> None:  # pragma: no cover - protocol
+        ...
+
+    def invalidate(self, keys: Iterable[str] | None = None, prefix: str | None = None) -> None:  # pragma: no cover - protocol
+        ...
+
+
+@dataclass
+class _CacheEntry:
+    value: Any
+    expires_at: float | None
+
+
+class InMemoryCacheBackend:
+    """Thread-safe in-memory cache backend supporting TTL and invalidation."""
+
+    def __init__(self) -> None:
+        self._store: Dict[str, _CacheEntry] = {}
+        self._lock = threading.Lock()
+
+    def get(self, key: str) -> Any | None:
+        with self._lock:
+            entry = self._store.get(key)
+            if not entry:
+                return None
+            if entry.expires_at is not None and entry.expires_at < time.monotonic():
+                self._store.pop(key, None)
+                return None
+            return entry.value
+
+    def set(self, key: str, value: Any, ttl: float | None = None) -> None:
+        expires_at = None
+        if ttl is not None:
+            expires_at = time.monotonic() + ttl
+        with self._lock:
+            self._store[key] = _CacheEntry(value=value, expires_at=expires_at)
+
+    def invalidate(self, keys: Iterable[str] | None = None, prefix: str | None = None) -> None:
+        with self._lock:
+            if keys:
+                for key in keys:
+                    self._store.pop(key, None)
+            if prefix:
+                for key in list(self._store.keys()):
+                    if key.startswith(prefix):
+                        self._store.pop(key, None)
+
+
+class RedisCacheBackend:
+    """Redis cache backend supporting TTL and targeted invalidation."""
+
+    def __init__(self, url: str, *, key_namespace: str = "") -> None:
+        if redis is None:  # pragma: no cover - optional dependency
+            raise RuntimeError("redis library is not installed")
+        self._client = redis.Redis.from_url(url)
+        self._namespace = key_namespace.rstrip(":") + ":" if key_namespace else ""
+
+    def _namespaced(self, key: str) -> str:
+        return f"{self._namespace}{key}"
+
+    def get(self, key: str) -> Any | None:
+        raw = self._client.get(self._namespaced(key))
+        if raw is None:
+            return None
+        return pickle.loads(raw)
+
+    def set(self, key: str, value: Any, ttl: float | None = None) -> None:
+        data = pickle.dumps(value)
+        namespaced = self._namespaced(key)
+        if ttl is None:
+            self._client.set(namespaced, data)
+        else:
+            self._client.set(namespaced, data, ex=ttl)
+
+    def invalidate(self, keys: Iterable[str] | None = None, prefix: str | None = None) -> None:
+        if keys:
+            namespaced_keys = [self._namespaced(key) for key in keys]
+            if namespaced_keys:
+                self._client.delete(*namespaced_keys)
+        if prefix:
+            pattern = f"{self._namespaced(prefix)}*"
+            for batch in self._scan_iter(pattern):
+                if batch:
+                    self._client.delete(*batch)
+
+    def _scan_iter(self, pattern: str, count: int = 1000):  # pragma: no cover - iterating helper
+        cursor = 0
+        while True:
+            cursor, keys = self._client.scan(cursor=cursor, match=pattern, count=count)
+            if keys:
+                yield keys
+            if cursor == 0:
+                break
+
+
+@dataclass
+class _InFlightCall:
+    future: Future
+    leader: bool
+
+
+class SingleFlight:
+    """Deduplicate concurrent executions for a given key."""
+
+    def __init__(self) -> None:
+        self._calls: Dict[str, _InFlightCall] = {}
+        self._lock = threading.Lock()
+
+    def execute(self, key: str, func: Callable[[], Any]) -> Any:
+        with self._lock:
+            call = self._calls.get(key)
+            if call is None:
+                call = _InFlightCall(future=Future(), leader=True)
+                self._calls[key] = call
+            else:
+                call.leader = False
+
+        if call.leader:
+            try:
+                result = func()
+            except Exception as exc:  # pragma: no cover - propagated to waiters
+                call.future.set_exception(exc)
+                raise
+            else:
+                call.future.set_result(result)
+            finally:
+                with self._lock:
+                    self._calls.pop(key, None)
+            return result
+
+        return call.future.result()
+
+
+class Cache:
+    """High-level cache wrapper combining backend storage and single-flight."""
+
+    def __init__(self, backend: CacheBackend, *, default_ttl: float | None = None) -> None:
+        self._backend = backend
+        self._default_ttl = default_ttl
+        self._singleflight = SingleFlight()
+
+    @property
+    def default_ttl(self) -> float | None:
+        return self._default_ttl
+
+    def get(self, key: str) -> Any | None:
+        return self._backend.get(key)
+
+    def set(self, key: str, value: Any, ttl: float | None = None) -> None:
+        ttl = self._default_ttl if ttl is None else ttl
+        self._backend.set(key, value, ttl)
+
+    def invalidate(self, *keys: str, prefix: str | None = None) -> None:
+        key_iterable: Iterable[str] | None = keys if keys else None
+        self._backend.invalidate(key_iterable, prefix=prefix)
+
+    def get_or_set(
+        self,
+        key: str,
+        loader: Callable[[], Any],
+        *,
+        ttl: float | None = None,
+        cache_predicate: Callable[[Any], bool] | None = None,
+    ) -> tuple[Any, bool]:
+        cached = self.get(key)
+        if cached is not None:
+            return cached, True
+
+        def _load() -> Any:
+            result = loader()
+            should_cache = result is not None
+            if cache_predicate is not None:
+                try:
+                    should_cache = should_cache and cache_predicate(result)
+                except Exception:
+                    should_cache = False
+            if should_cache:
+                effective_ttl = self._default_ttl if ttl is None else ttl
+                self._backend.set(key, result, effective_ttl)
+            return result
+
+        result = self._singleflight.execute(key, _load)
+        return result, False
+
+
+__all__ = [
+    "Cache",
+    "CacheBackend",
+    "InMemoryCacheBackend",
+    "RedisCacheBackend",
+    "SingleFlight",
+]

--- a/src/routes/proxy.py
+++ b/src/routes/proxy.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from typing import Dict, Iterable, Tuple
 
 import requests
+import time
 from flask import Blueprint, Response, current_app, g, request
+from opentelemetry import trace
+from opentelemetry.trace import Status, StatusCode
 
 from ..app import limiter
 from ..transformations import (
@@ -25,122 +28,225 @@ from ..services.registry import ServiceInstance, ServiceRegistry
 from ..utils.responses import error_response
 
 proxy_bp = Blueprint("proxy", __name__)
+tracer = trace.get_tracer(__name__)
 
 
 def _forward(path: str) -> Response:
     """Forward a request to the upstream user service."""
 
-    headers = _prepare_headers()
-    data = request.get_data(cache=False)
-    params = list(request.args.items(multi=True))
+    metrics = current_app.extensions.get("metrics")
+    span_attributes = {
+        "http.method": request.method,
+        "http.target": request.full_path.rstrip("?") or request.path,
+        "http.route": getattr(request.url_rule, "rule", request.path),
+        "http.request_id": getattr(g, "request_id", None),
+        "upstream.service": current_app.config.get("USER_SERVICE_NAME", "user-service"),
+    }
+    span_attributes = {k: v for k, v in span_attributes.items() if v is not None}
 
-    pipeline = current_app.extensions.get("transformation_pipeline")
-    request_message: RequestMessage | None = None
+    with tracer.start_as_current_span("proxy.forward", attributes=span_attributes) as span:
+        headers = _prepare_headers()
+        data = request.get_data(cache=False)
+        params = list(request.args.items(multi=True))
 
-    if pipeline:
-        request_message = RequestMessage(
-            method=request.method,
-            gateway_path=request.path,
-            upstream_path=path,
-            headers=dict(headers),
-            query_params=tuple(params),
-            body=data,
-            content_type=request.headers.get("Content-Type"),
-            host_url=request.host_url,
-        )
-        try:
-            request_message = pipeline.apply_request(request_message)
-        except OpenAPIValidationError as exc:
-            current_app.logger.warning("OpenAPI request validation failed: %s", exc)
-            return error_response(400, "Invalid request payload")
-        except TransformationError as exc:
-            current_app.logger.warning("Request transformation failed: %s", exc)
-            return error_response(400, "Request transformation error")
+        pipeline = current_app.extensions.get("transformation_pipeline")
+        request_message: RequestMessage | None = None
 
-        headers = dict(request_message.headers)
-        data = request_message.body
-        params = list(request_message.query_params)
-        upstream_path = request_message.upstream_path or ""
-        path = upstream_path.lstrip("/")
-
-    timeout = (
-        current_app.config.get("PROXY_TIMEOUT_CONNECT", 2.0),
-        current_app.config.get("PROXY_TIMEOUT_READ", 10.0),
-    )
-
-    registry: ServiceRegistry | None = current_app.extensions.get("service_registry")
-    resilience: ResilienceMiddleware | None = current_app.extensions.get(
-        "resilience_middleware"
-    )
-    service_name = current_app.config.get("USER_SERVICE_NAME", "user-service")
-    strategy_name = current_app.config.get("LOAD_BALANCER_STRATEGY", "round_robin")
-
-    def perform_request(instance: ServiceInstance) -> requests.Response:
-        base_url = instance.url.rstrip("/")
-        url = f"{base_url}/{path}" if path else base_url
-        try:
-            return requests.request(
+        if pipeline:
+            request_message = RequestMessage(
                 method=request.method,
-                url=url,
-                headers=headers,
-                params=params,
-                data=data,
-                timeout=timeout,
+                gateway_path=request.path,
+                upstream_path=path,
+                headers=dict(headers),
+                query_params=tuple(params),
+                body=data,
+                content_type=request.headers.get("Content-Type"),
+                host_url=request.host_url,
             )
-        except requests.RequestException as exc:
-            raise UpstreamRequestError(str(exc)) from exc
+            try:
+                with tracer.start_as_current_span("proxy.transform_request"):
+                    request_message = pipeline.apply_request(request_message)
+            except OpenAPIValidationError as exc:
+                span.record_exception(exc)
+                span.set_status(
+                    Status(status_code=StatusCode.ERROR, description="request_validation_failed")
+                )
+                current_app.logger.warning("OpenAPI request validation failed: %s", exc)
+                return error_response(400, "Invalid request payload")
+            except TransformationError as exc:
+                span.record_exception(exc)
+                span.set_status(
+                    Status(
+                        status_code=StatusCode.ERROR,
+                        description="request_transformation_failed",
+                    )
+                )
+                current_app.logger.warning("Request transformation failed: %s", exc)
+                return error_response(400, "Request transformation error")
 
-    if registry and resilience:
+            headers = dict(request_message.headers)
+            data = request_message.body
+            params = list(request_message.query_params)
+            upstream_path = request_message.upstream_path or ""
+            path = upstream_path.lstrip("/")
+
+        timeout = (
+            current_app.config.get("PROXY_TIMEOUT_CONNECT", 2.0),
+            current_app.config.get("PROXY_TIMEOUT_READ", 10.0),
+        )
+
+        registry: ServiceRegistry | None = current_app.extensions.get("service_registry")
+        resilience: ResilienceMiddleware | None = current_app.extensions.get(
+            "resilience_middleware"
+        )
+        service_name = current_app.config.get("USER_SERVICE_NAME", "user-service")
+        strategy_name = current_app.config.get("LOAD_BALANCER_STRATEGY", "round_robin")
+
+        def perform_request(instance: ServiceInstance) -> requests.Response:
+            base_url = instance.url.rstrip("/")
+            url = f"{base_url}/{path}" if path else base_url
+            upstream_attributes = {
+                "http.method": request.method,
+                "upstream.url": url,
+                "upstream.service": instance.service_name,
+            }
+            upstream_attributes = {
+                key: value for key, value in upstream_attributes.items() if value is not None
+            }
+            with tracer.start_as_current_span(
+                "proxy.upstream_request", attributes=upstream_attributes
+            ) as upstream_span:
+                start = time.perf_counter()
+                try:
+                    response = requests.request(
+                        method=request.method,
+                        url=url,
+                        headers=headers,
+                        params=params,
+                        data=data,
+                        timeout=timeout,
+                    )
+                except requests.RequestException as exc:
+                    duration = time.perf_counter() - start
+                    upstream_span.record_exception(exc)
+                    upstream_span.set_status(
+                        Status(status_code=StatusCode.ERROR, description=str(exc))
+                    )
+                    if metrics:
+                        metrics.record_upstream_failure(
+                            service=instance.service_name, reason=exc.__class__.__name__
+                        )
+                        metrics.observe_upstream_latency(
+                            service=instance.service_name,
+                            status=599,
+                            duration_seconds=duration,
+                        )
+                    raise UpstreamRequestError(str(exc)) from exc
+
+                duration = time.perf_counter() - start
+                upstream_span.set_attribute("http.status_code", response.status_code)
+                upstream_span.set_attribute(
+                    "http.response_content_length", len(response.content or b"")
+                )
+                upstream_span.set_attribute("http.response_time_ms", duration * 1000.0)
+                if metrics:
+                    metrics.observe_upstream_latency(
+                        service=instance.service_name,
+                        status=response.status_code,
+                        duration_seconds=duration,
+                    )
+                return response
+
         try:
-            upstream_response = resilience.execute(
-                registry=registry,
-                service_name=service_name,
-                strategy_name=strategy_name,
-                request_func=perform_request,
+            if registry and resilience:
+                upstream_response = resilience.execute(
+                    registry=registry,
+                    service_name=service_name,
+                    strategy_name=strategy_name,
+                    request_func=perform_request,
+                )
+            else:
+                base_url = current_app.config.get("USER_SERVICE_URL", "").rstrip("/")
+                if not base_url:
+                    span.set_status(
+                        Status(
+                            status_code=StatusCode.ERROR,
+                            description="upstream_not_configured",
+                        )
+                    )
+                    return error_response(503, "Service Unavailable")
+                fallback_instance = ServiceInstance(service_name=service_name, url=base_url)
+                upstream_response = perform_request(fallback_instance)
+        except ServiceUnavailableError as exc:
+            span.record_exception(exc)
+            span.set_status(
+                Status(status_code=StatusCode.ERROR, description="service_unavailable")
             )
-        except ServiceUnavailableError:
             return error_response(503, "Service Unavailable")
-        except UpstreamServiceError:
-            return error_response(502, "Bad Gateway")
-    else:
-        base_url = current_app.config.get("USER_SERVICE_URL", "").rstrip("/")
-        if not base_url:
-            return error_response(503, "Service Unavailable")
-        fallback_instance = ServiceInstance(service_name=service_name, url=base_url)
-        try:
-            upstream_response = perform_request(fallback_instance)
-        except UpstreamRequestError:
-            return error_response(502, "Bad Gateway")
-
-    response_message = ResponseMessage(
-        status_code=upstream_response.status_code,
-        headers=tuple(upstream_response.headers.items()),
-        body=upstream_response.content,
-        content_type=upstream_response.headers.get("Content-Type"),
-    )
-
-    if pipeline and request_message:
-        try:
-            response_message = pipeline.apply_response(
-                response_message, request_message=request_message
+        except UpstreamServiceError as exc:
+            span.record_exception(exc)
+            span.set_status(
+                Status(status_code=StatusCode.ERROR, description="upstream_service_error")
             )
-        except OpenAPIValidationError as exc:
-            current_app.logger.warning("OpenAPI response validation failed: %s", exc)
-            return error_response(502, "Upstream response validation error")
-        except TransformationError as exc:
-            current_app.logger.warning("Response transformation failed: %s", exc)
-            return error_response(502, "Response transformation error")
+            return error_response(502, "Bad Gateway")
+        except UpstreamRequestError as exc:
+            span.record_exception(exc)
+            span.set_status(
+                Status(status_code=StatusCode.ERROR, description="upstream_request_error")
+            )
+            return error_response(502, "Bad Gateway")
 
-    response_headers = _filter_response_headers(response_message.headers)
-    set_cookie_headers = _extract_set_cookie_headers(upstream_response)
-    if set_cookie_headers:
-        response_headers.extend(("Set-Cookie", value) for value in set_cookie_headers)
+        response_message = ResponseMessage(
+            status_code=upstream_response.status_code,
+            headers=tuple(upstream_response.headers.items()),
+            body=upstream_response.content,
+            content_type=upstream_response.headers.get("Content-Type"),
+        )
 
-    return Response(
-        response_message.body,
-        response_message.status_code,
-        response_headers,
-    )
+        if pipeline and request_message:
+            try:
+                with tracer.start_as_current_span("proxy.transform_response"):
+                    response_message = pipeline.apply_response(
+                        response_message, request_message=request_message
+                    )
+            except OpenAPIValidationError as exc:
+                span.record_exception(exc)
+                span.set_status(
+                    Status(
+                        status_code=StatusCode.ERROR,
+                        description="response_validation_failed",
+                    )
+                )
+                current_app.logger.warning("OpenAPI response validation failed: %s", exc)
+                return error_response(502, "Upstream response validation error")
+            except TransformationError as exc:
+                span.record_exception(exc)
+                span.set_status(
+                    Status(
+                        status_code=StatusCode.ERROR,
+                        description="response_transformation_failed",
+                    )
+                )
+                current_app.logger.warning("Response transformation failed: %s", exc)
+                return error_response(502, "Response transformation error")
+
+        response_headers = _filter_response_headers(response_message.headers)
+        set_cookie_headers = _extract_set_cookie_headers(upstream_response)
+        if set_cookie_headers:
+            response_headers.extend(("Set-Cookie", value) for value in set_cookie_headers)
+
+        span.set_attribute("http.status_code", response_message.status_code)
+        span.set_attribute("http.response_content_length", len(response_message.body or b""))
+        if response_message.status_code >= 500:
+            span.set_status(Status(StatusCode.ERROR))
+        else:
+            span.set_status(Status(StatusCode.OK))
+
+        return Response(
+            response_message.body,
+            response_message.status_code,
+            response_headers,
+        )
 
 
 def _prepare_headers() -> Dict[str, str]:

--- a/src/security/__init__.py
+++ b/src/security/__init__.py
@@ -1,0 +1,13 @@
+"""Security utilities for the Meetinity API Gateway."""
+
+from .api_keys import APIKeyMiddleware, APIKeyStore
+from .oauth import OIDCProvider
+from .signatures import RequestSignatureMiddleware, RequestSigner
+
+__all__ = [
+    "APIKeyMiddleware",
+    "APIKeyStore",
+    "OIDCProvider",
+    "RequestSignatureMiddleware",
+    "RequestSigner",
+]

--- a/src/security/api_keys.py
+++ b/src/security/api_keys.py
@@ -1,0 +1,191 @@
+"""API key management and validation utilities."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import time
+from dataclasses import dataclass
+from typing import Dict, Iterable, Mapping, Optional, Sequence
+
+from flask import Flask, Request, request
+
+from ..utils.responses import error_response
+
+
+DEFAULT_HASH_ALGORITHM = "sha256"
+
+
+def _hash_value(value: str, algorithm: str = DEFAULT_HASH_ALGORITHM) -> str:
+    """Return the hexadecimal digest for ``value`` using ``algorithm``."""
+
+    hasher = hashlib.new(algorithm)
+    hasher.update(value.encode("utf-8"))
+    return hasher.hexdigest()
+
+
+@dataclass(frozen=True)
+class StoredAPIKey:
+    """Represent an API key stored in the gateway."""
+
+    key_id: str
+    hashed_secret: str
+    created_at: float
+
+
+class APIKeyStore:
+    """Securely store API keys as salted hashes and validate presented secrets."""
+
+    def __init__(
+        self,
+        *,
+        keys: Optional[Mapping[str, str]] = None,
+        salt: str = "",
+        algorithm: str = DEFAULT_HASH_ALGORITHM,
+    ) -> None:
+        self._salt = salt
+        self._algorithm = algorithm
+        self._keys: Dict[str, StoredAPIKey] = {}
+        if keys:
+            for key_id, secret in keys.items():
+                self.add_key(key_id, secret, hashed=False)
+
+    @classmethod
+    def from_environment(cls, env: Mapping[str, str] | None = None) -> "APIKeyStore":
+        """Create a key store from environment variables.
+
+        Keys are read from the ``API_KEYS`` variable using the format
+        ``<key-id>:<secret>`` separated by commas. Secrets are hashed immediately
+        using the configured algorithm.
+        """
+
+        env = env or os.environ
+        raw_keys = env.get("API_KEYS", "")
+        salt = env.get("API_KEY_SALT", "")
+        algorithm = env.get("API_KEY_HASH_ALGORITHM", DEFAULT_HASH_ALGORITHM)
+
+        parsed: Dict[str, str] = {}
+        for token in _split_csv(raw_keys):
+            if ":" not in token:
+                continue
+            key_id, secret = token.split(":", 1)
+            key_id = key_id.strip()
+            secret = secret.strip()
+            if key_id and secret:
+                parsed[key_id] = secret
+        return cls(keys=parsed, salt=salt, algorithm=algorithm)
+
+    @property
+    def salt(self) -> str:
+        return self._salt
+
+    @property
+    def algorithm(self) -> str:
+        return self._algorithm
+
+    def add_key(self, key_id: str, secret: str, *, hashed: bool = False) -> None:
+        """Add a new API key to the store."""
+
+        if not key_id:
+            raise ValueError("key_id must not be empty")
+        if not secret:
+            raise ValueError("secret must not be empty")
+
+        stored_secret = secret if hashed else self._hash_secret(secret)
+        self._keys[key_id] = StoredAPIKey(
+            key_id=key_id,
+            hashed_secret=stored_secret,
+            created_at=time.time(),
+        )
+
+    def remove_key(self, key_id: str) -> None:
+        """Remove an API key from the store if it exists."""
+
+        self._keys.pop(key_id, None)
+
+    def validate(self, provided_secret: str) -> bool:
+        """Validate the provided API key secret against stored hashes."""
+
+        if not provided_secret:
+            return False
+        candidate = self._hash_secret(provided_secret)
+        for stored in self._keys.values():
+            if hmac.compare_digest(stored.hashed_secret, candidate):
+                return True
+        return False
+
+    def _hash_secret(self, secret: str) -> str:
+        salted = f"{secret}{self._salt}" if self._salt else secret
+        return _hash_value(salted, self._algorithm)
+
+    def as_dict(self) -> Dict[str, StoredAPIKey]:
+        """Return a shallow copy of stored keys for inspection/testing."""
+
+        return dict(self._keys)
+
+
+def _split_csv(raw: str) -> Sequence[str]:
+    return [token.strip() for token in raw.split(",") if token.strip()]
+
+
+class APIKeyMiddleware:
+    """Flask middleware enforcing API key validation for incoming requests."""
+
+    def __init__(
+        self,
+        app: Flask,
+        store: APIKeyStore,
+        *,
+        header_name: str = "X-API-Key",
+        enabled: bool = True,
+        exempt_paths: Optional[Iterable[str]] = None,
+    ) -> None:
+        self.app = app
+        self.store = store
+        self.header_name = header_name
+        self.enabled = enabled
+        self.exempt_paths = tuple(exempt_paths or ("/health",))
+        if enabled:
+            app.before_request(self._enforce_api_key)
+
+    def _is_exempt(self, req: Request) -> bool:
+        path = req.path or "/"
+        return any(path.startswith(prefix) for prefix in self.exempt_paths)
+
+    def _enforce_api_key(self):
+        if not self.enabled:
+            return None
+        if self._is_exempt(request):
+            return None
+
+        provided = request.headers.get(self.header_name)
+        if not provided:
+            return error_response(401, "API key required")
+        if not self.store.validate(provided):
+            return error_response(403, "Invalid API key")
+        return None
+
+
+def configure_api_keys(app: Flask) -> Optional[APIKeyMiddleware]:
+    """Configure API key middleware from application configuration."""
+
+    store = APIKeyStore.from_environment(app.config)
+    enabled = app.config.get("API_KEY_REQUIRED", bool(store.as_dict()))
+    header_name = app.config.get("API_KEY_HEADER", "X-API-Key")
+    exempt_paths = app.config.get("API_KEY_EXEMPT_PATHS", ("/health",))
+
+    if not enabled:
+        app.logger.info("API key middleware disabled")
+        app.extensions["api_key_store"] = store
+        return None
+
+    middleware = APIKeyMiddleware(
+        app,
+        store,
+        header_name=header_name,
+        enabled=True,
+        exempt_paths=exempt_paths,
+    )
+    app.extensions["api_key_store"] = store
+    return middleware

--- a/src/security/oauth.py
+++ b/src/security/oauth.py
@@ -1,0 +1,182 @@
+"""OAuth 2.0 and OpenID Connect utilities."""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Mapping, Optional
+
+import jwt
+import requests
+from jwt import InvalidTokenError, PyJWTError
+
+
+class DiscoveryError(RuntimeError):
+    """Raised when metadata discovery fails."""
+
+
+class TokenValidationError(RuntimeError):
+    """Raised when a token cannot be validated."""
+
+
+@dataclass
+class ProviderMetadata:
+    """Container for OpenID Connect discovery metadata."""
+
+    issuer: str
+    authorization_endpoint: Optional[str]
+    token_endpoint: Optional[str]
+    jwks_uri: Optional[str]
+    introspection_endpoint: Optional[str]
+    userinfo_endpoint: Optional[str]
+    algorithms: Iterable[str]
+
+
+class OIDCProvider:
+    """Interact with an OpenID Connect provider."""
+
+    def __init__(
+        self,
+        issuer: str,
+        *,
+        session: Optional[requests.Session] = None,
+        cache_ttl: int = 300,
+    ) -> None:
+        self.issuer = issuer.rstrip("/")
+        self._session = session or requests.Session()
+        self._cache_ttl = cache_ttl
+        self._metadata: Optional[ProviderMetadata] = None
+        self._metadata_expires_at = 0.0
+        self._jwks_cache: Optional[Dict[str, Any]] = None
+        self._jwks_expires_at = 0.0
+
+    def discover(self, *, force: bool = False) -> ProviderMetadata:
+        """Fetch the provider metadata using the discovery document."""
+
+        if not force and self._metadata and time.time() < self._metadata_expires_at:
+            return self._metadata
+
+        url = f"{self.issuer}/.well-known/openid-configuration"
+        response = self._session.get(url, timeout=5)
+        if response.status_code != 200:
+            raise DiscoveryError(f"Discovery failed with status {response.status_code}")
+
+        payload = response.json()
+        metadata = ProviderMetadata(
+            issuer=payload.get("issuer", self.issuer),
+            authorization_endpoint=payload.get("authorization_endpoint"),
+            token_endpoint=payload.get("token_endpoint"),
+            jwks_uri=payload.get("jwks_uri"),
+            introspection_endpoint=payload.get("introspection_endpoint"),
+            userinfo_endpoint=payload.get("userinfo_endpoint"),
+            algorithms=payload.get("id_token_signing_alg_values_supported", []),
+        )
+        self._metadata = metadata
+        self._metadata_expires_at = time.time() + self._cache_ttl
+        return metadata
+
+    def metadata(self) -> ProviderMetadata:
+        """Return cached metadata, performing discovery if needed."""
+
+        return self.discover()
+
+    def _get_jwks(self, *, force: bool = False) -> Dict[str, Any]:
+        metadata = self.metadata()
+        if not metadata.jwks_uri:
+            raise DiscoveryError("Provider metadata does not expose a jwks_uri")
+
+        if not force and self._jwks_cache and time.time() < self._jwks_expires_at:
+            return self._jwks_cache
+
+        response = self._session.get(metadata.jwks_uri, timeout=5)
+        if response.status_code != 200:
+            raise DiscoveryError("Failed to fetch JWKS")
+        data = response.json()
+        self._jwks_cache = data
+        self._jwks_expires_at = time.time() + self._cache_ttl
+        return data
+
+    def validate_token(
+        self,
+        token: str,
+        *,
+        audience: Optional[str] = None,
+        leeway: int = 0,
+        client_secret: Optional[str] = None,
+        require_signature: bool = True,
+    ) -> Dict[str, Any]:
+        """Validate an ID/access token against provider metadata."""
+
+        metadata = self.metadata()
+        header = jwt.get_unverified_header(token)
+        algorithm = header.get("alg")
+        options = {"require": ["exp", "iat"], "verify_aud": audience is not None}
+
+        try:
+            if algorithm and algorithm.startswith("HS"):
+                if not client_secret:
+                    raise TokenValidationError("client_secret required for HMAC tokens")
+                payload = jwt.decode(
+                    token,
+                    client_secret,
+                    algorithms=[algorithm] if algorithm else None,
+                    audience=audience,
+                    issuer=metadata.issuer,
+                    leeway=leeway,
+                    options=options,
+                )
+            else:
+                key = self._resolve_jwk_for_token(header)
+                if not require_signature and not key:
+                    decode_options = {"verify_signature": False, **options}
+                    payload = jwt.decode(
+                        token,
+                        None,
+                        audience=audience,
+                        issuer=metadata.issuer,
+                        leeway=leeway,
+                        options=decode_options,
+                    )
+                elif not key:
+                    raise TokenValidationError("Unable to resolve signing key for token")
+                else:
+                    public_key = _jwk_to_public_key(key)
+                    payload = jwt.decode(
+                        token,
+                        public_key,
+                        algorithms=[algorithm] if algorithm else None,
+                        audience=audience,
+                        issuer=metadata.issuer,
+                        leeway=leeway,
+                        options=options,
+                    )
+        except (InvalidTokenError, PyJWTError) as exc:
+            raise TokenValidationError(str(exc)) from exc
+
+        return payload
+
+    def _resolve_jwk_for_token(self, header: Mapping[str, Any]) -> Optional[Mapping[str, Any]]:
+        jwks = self._get_jwks()
+        keys = jwks.get("keys", []) if isinstance(jwks, Mapping) else []
+        kid = header.get("kid")
+        alg = header.get("alg")
+
+        for jwk in keys:
+            if kid and jwk.get("kid") != kid:
+                continue
+            if alg and jwk.get("alg") not in (None, alg):
+                continue
+            return jwk
+        return None
+
+
+def _jwk_to_public_key(jwk_dict: Mapping[str, Any]):
+    """Convert a JWK dictionary into a public key object for PyJWT."""
+
+    try:
+        from jwt.algorithms import RSAAlgorithm
+    except ImportError as exc:  # pragma: no cover - depends on optional dependency
+        raise TokenValidationError("RSA validation requires cryptography support") from exc
+
+    return RSAAlgorithm.from_jwk(json.dumps(jwk_dict))

--- a/src/security/signatures.py
+++ b/src/security/signatures.py
@@ -1,0 +1,175 @@
+"""Request signing utilities for inbound and outbound traffic."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import time
+from typing import Iterable, Mapping, Optional
+
+from flask import Flask, Request, request
+
+from ..utils.responses import error_response
+
+
+def _canonical_request(
+    req: Request,
+    *,
+    headers: Optional[Iterable[str]] = None,
+    timestamp: str,
+) -> bytes:
+    body_bytes = req.get_data(cache=True) or b""
+    if isinstance(body_bytes, str):
+        body_bytes = body_bytes.encode("utf-8")
+
+    hashed_body = hashlib.sha256(body_bytes).hexdigest()
+    header_values = []
+    if headers:
+        for header in headers:
+            value = req.headers.get(header, "")
+            header_values.append(f"{header.lower()}:{value.strip()}")
+    canonical = "\n".join(
+        [
+            req.method.upper(),
+            req.path,
+            hashed_body,
+            timestamp,
+            "\n".join(sorted(header_values)),
+        ]
+    )
+    return canonical.encode("utf-8")
+
+
+class RequestSigner:
+    """Sign outbound requests using shared HMAC secrets."""
+
+    def __init__(self, secret: str, *, algorithm: str = "sha256") -> None:
+        self.secret = secret.encode("utf-8")
+        self.algorithm = algorithm.lower()
+
+    def sign(
+        self,
+        req: Request,
+        *,
+        timestamp: Optional[str] = None,
+        headers: Optional[Iterable[str]] = None,
+    ) -> str:
+        timestamp = timestamp or str(int(time.time()))
+        canonical = _canonical_request(req, headers=headers, timestamp=timestamp)
+        digest = hmac.new(self.secret, canonical, self.algorithm).digest()
+        signature = base64.b64encode(digest).decode("ascii")
+        return signature
+
+
+class RequestSignatureMiddleware:
+    """Middleware validating signed requests using HMAC."""
+
+    def __init__(
+        self,
+        app: Flask,
+        secrets: Mapping[str, str],
+        *,
+        header_signature: str = "X-Signature",
+        header_timestamp: str = "X-Timestamp",
+        header_key_id: str = "X-Client-Id",
+        headers_to_include: Optional[Iterable[str]] = None,
+        algorithm: str = "sha256",
+        clock_tolerance: int = 300,
+        enabled: bool = True,
+        exempt_paths: Optional[Iterable[str]] = None,
+    ) -> None:
+        self.app = app
+        self.secrets = {key_id: value.encode("utf-8") for key_id, value in secrets.items()}
+        self.header_signature = header_signature
+        self.header_timestamp = header_timestamp
+        self.header_key_id = header_key_id
+        self.headers_to_include = tuple(headers_to_include or ())
+        self.algorithm = algorithm.lower()
+        self.clock_tolerance = clock_tolerance
+        self.enabled = enabled and bool(self.secrets)
+        self.exempt_paths = tuple(exempt_paths or ("/health",))
+        if self.enabled:
+            app.before_request(self._verify_signature)
+
+    def _is_exempt(self, req: Request) -> bool:
+        path = req.path or "/"
+        return any(path.startswith(prefix) for prefix in self.exempt_paths)
+
+    def _verify_signature(self):
+        if not self.enabled:
+            return None
+        if self._is_exempt(request):
+            return None
+
+        key_id = request.headers.get(self.header_key_id)
+        signature = request.headers.get(self.header_signature)
+        timestamp = request.headers.get(self.header_timestamp)
+
+        if not key_id or not signature or not timestamp:
+            return error_response(401, "Signed request headers missing")
+
+        secret = self.secrets.get(key_id)
+        if not secret:
+            return error_response(403, "Unknown signing key")
+
+        if not self._is_timestamp_valid(timestamp):
+            return error_response(401, "Expired signature")
+
+        canonical = _canonical_request(request, headers=self.headers_to_include, timestamp=timestamp)
+        expected = base64.b64encode(
+            hmac.new(secret, canonical, self.algorithm).digest()
+        ).decode("ascii")
+
+        if not hmac.compare_digest(expected, signature):
+            return error_response(403, "Invalid signature")
+
+        return None
+
+    def _is_timestamp_valid(self, timestamp: str) -> bool:
+        try:
+            ts = int(timestamp)
+        except ValueError:
+            return False
+        now = int(time.time())
+        return abs(now - ts) <= self.clock_tolerance
+
+
+def configure_request_signatures(app: Flask) -> Optional[RequestSignatureMiddleware]:
+    """Configure request signature verification middleware."""
+
+    secrets_raw = app.config.get("SIGNING_SECRETS", "")
+    secrets = {}
+    for token in [part.strip() for part in secrets_raw.split(",") if part.strip()]:
+        if ":" not in token:
+            continue
+        key_id, secret = token.split(":", 1)
+        if key_id and secret:
+            secrets[key_id.strip()] = secret.strip()
+
+    enabled = app.config.get("REQUEST_SIGNATURES_ENABLED", bool(secrets))
+    header_signature = app.config.get("SIGNATURE_HEADER", "X-Signature")
+    header_timestamp = app.config.get("SIGNATURE_TIMESTAMP_HEADER", "X-Timestamp")
+    header_key_id = app.config.get("SIGNATURE_KEY_ID_HEADER", "X-Client-Id")
+    algorithm = app.config.get("SIGNATURE_ALGORITHM", "sha256")
+    clock_tolerance = int(app.config.get("SIGNATURE_CLOCK_TOLERANCE", 300))
+    headers_to_include = app.config.get("SIGNATURE_HEADERS", [])
+    exempt_paths = app.config.get("SIGNATURE_EXEMPT_PATHS", ("/health",))
+
+    if not enabled or not secrets:
+        app.logger.info("Request signature middleware disabled")
+        return None
+
+    middleware = RequestSignatureMiddleware(
+        app,
+        secrets,
+        header_signature=header_signature,
+        header_timestamp=header_timestamp,
+        header_key_id=header_key_id,
+        headers_to_include=headers_to_include,
+        algorithm=algorithm,
+        clock_tolerance=clock_tolerance,
+        exempt_paths=exempt_paths,
+    )
+    app.extensions["request_signature_middleware"] = middleware
+    return middleware

--- a/src/transformations/__init__.py
+++ b/src/transformations/__init__.py
@@ -1,0 +1,21 @@
+"""Transformation pipeline utilities for the API gateway."""
+
+from .pipeline import (
+    OpenAPIValidationError,
+    RequestMessage,
+    ResponseMessage,
+    TransformationError,
+    TransformationPipeline,
+    build_pipeline,
+)
+from .rules import load_transformation_rules
+
+__all__ = [
+    "OpenAPIValidationError",
+    "RequestMessage",
+    "ResponseMessage",
+    "TransformationError",
+    "TransformationPipeline",
+    "build_pipeline",
+    "load_transformation_rules",
+]

--- a/src/transformations/adapters.py
+++ b/src/transformations/adapters.py
@@ -1,0 +1,193 @@
+"""Data conversion adapters used by the transformation pipeline."""
+from __future__ import annotations
+
+import csv
+import io
+import json
+from typing import Any, Iterable, Mapping, Sequence
+from xml.etree import ElementTree as ET
+
+
+def convert_between_formats(
+    body: bytes | None,
+    source_format: str,
+    target_format: str,
+) -> tuple[bytes | None, str | None]:
+    """Convert ``body`` between textual formats."""
+
+    if body is None:
+        return None, _content_type_for(target_format)
+
+    source_format = source_format.lower()
+    target_format = target_format.lower()
+
+    if source_format == target_format:
+        return body, _content_type_for(target_format)
+
+    data = _decode(body, source_format)
+    converted = _encode(data, target_format)
+    return converted, _content_type_for(target_format)
+
+
+def rest_to_graphql(
+    *,
+    method: str,
+    path: str,
+    query_params: Sequence[tuple[str, str]] | None,
+    body: Any,
+) -> dict[str, Any]:
+    """Convert a REST-like request description into a GraphQL payload."""
+
+    method = (method or "GET").upper()
+    normalized_path = path or "/"
+    field_name = _normalize_field_name(normalized_path)
+    operation_type = "query" if method == "GET" else "mutation"
+    operation_name = field_name.title().replace("_", "") or "Root"
+
+    variables: dict[str, Any] = {"method": method, "path": normalized_path}
+    if query_params:
+        normalized_query: dict[str, list[str]] = {}
+        for key, value in query_params:
+            normalized_query.setdefault(key, []).append(str(value))
+        variables["query"] = normalized_query
+    if body is not None:
+        variables["body"] = body
+
+    query = f"{operation_type} {operation_name} {{ {field_name or 'root'} }}"
+    return {"query": query, "variables": variables}
+
+
+def graphql_to_rest(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Convert a GraphQL payload into a simplified REST description."""
+
+    variables = payload.get("variables")
+    if not isinstance(variables, Mapping):
+        return {}
+
+    method = str(variables.get("method", "POST")).upper()
+    path = str(variables.get("path", "/"))
+    query_params: list[tuple[str, str]] = []
+    raw_query = variables.get("query")
+    if isinstance(raw_query, Mapping):
+        for key, value in raw_query.items():
+            if isinstance(value, (list, tuple)):
+                query_params.extend((key, str(item)) for item in value)
+            else:
+                query_params.append((key, str(value)))
+
+    body = variables.get("body")
+
+    return {
+        "method": method,
+        "path": path,
+        "query_params": tuple(query_params),
+        "body": body,
+    }
+
+
+def _decode(body: bytes, fmt: str) -> Any:
+    text = body.decode("utf-8")
+    if fmt == "json":
+        return json.loads(text)
+    if fmt == "xml":
+        return _xml_to_data(text)
+    if fmt == "csv":
+        return _csv_to_data(text)
+    raise ValueError(f"Unsupported format: {fmt}")
+
+
+def _encode(data: Any, fmt: str) -> bytes:
+    if fmt == "json":
+        return json.dumps(data).encode("utf-8")
+    if fmt == "xml":
+        return _data_to_xml(data)
+    if fmt == "csv":
+        return _data_to_csv(data)
+    raise ValueError(f"Unsupported format: {fmt}")
+
+
+def _content_type_for(fmt: str | None) -> str | None:
+    if fmt == "json":
+        return "application/json"
+    if fmt == "xml":
+        return "application/xml"
+    if fmt == "csv":
+        return "text/csv"
+    return None
+
+
+def _normalize_field_name(path: str) -> str:
+    stripped = path.strip("/")
+    if not stripped:
+        return "root"
+    return stripped.replace("/", "_")
+
+
+def _xml_to_data(text: str) -> Any:
+    root = ET.fromstring(text)
+    return _element_to_value(root)
+
+
+def _element_to_value(element: ET.Element) -> Any:
+    children = list(element)
+    if not children:
+        text = element.text or ""
+        return text.strip()
+
+    result: dict[str, Any] = {}
+    for child in children:
+        value = _element_to_value(child)
+        if child.tag in result:
+            existing = result[child.tag]
+            if isinstance(existing, list):
+                existing.append(value)
+            else:
+                result[child.tag] = [existing, value]
+        else:
+            result[child.tag] = value
+    return result
+
+
+def _data_to_xml(data: Any) -> bytes:
+    root = ET.Element("root")
+    _append_value(root, data)
+    return ET.tostring(root, encoding="utf-8")
+
+
+def _append_value(element: ET.Element, value: Any) -> None:
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            child = ET.SubElement(element, str(key))
+            _append_value(child, item)
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            child = ET.SubElement(element, "item")
+            _append_value(child, item)
+    else:
+        element.text = "" if value is None else str(value)
+
+
+def _csv_to_data(text: str) -> Any:
+    reader = csv.DictReader(io.StringIO(text))
+    return [row for row in reader]
+
+
+def _data_to_csv(data: Any) -> bytes:
+    rows: list[Mapping[str, Any]]
+    if isinstance(data, Mapping):
+        rows = [data]
+    elif isinstance(data, Iterable):
+        rows = [row for row in data if isinstance(row, Mapping)]
+    else:
+        rows = [{"value": data}]
+
+    if not rows:
+        return b""
+
+    fieldnames = sorted({key for row in rows for key in row.keys()})
+    buffer = io.StringIO()
+    writer = csv.DictWriter(buffer, fieldnames=fieldnames)
+    writer.writeheader()
+    for row in rows:
+        writer.writerow({key: row.get(key, "") for key in fieldnames})
+    return buffer.getvalue().encode("utf-8")

--- a/src/transformations/pipeline.py
+++ b/src/transformations/pipeline.py
@@ -1,0 +1,454 @@
+"""Transformation pipeline implementation."""
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+import json
+from pathlib import Path
+from typing import Any, Callable, Iterable, List, Mapping, Sequence
+
+from openapi_core.validation.request.validators import V30RequestValidator
+from openapi_core.validation.request.validators import V31RequestValidator
+from openapi_core.validation.response.validators import V30ResponseValidator
+from openapi_core.validation.response.validators import V31ResponseValidator
+
+from .adapters import (
+    convert_between_formats,
+    graphql_to_rest,
+    rest_to_graphql,
+)
+from .rules import load_transformation_rules
+from .validators import OpenAPIValidationError as _ValidatorError
+from .validators import OpenAPIValidator
+
+
+class TransformationError(Exception):
+    """Base error raised for transformation issues."""
+
+
+class OpenAPIValidationError(TransformationError, _ValidatorError):
+    """Raised when OpenAPI validation fails."""
+
+
+@dataclass
+class RequestMessage:
+    """Representation of an incoming request for transformations."""
+
+    method: str
+    gateway_path: str
+    upstream_path: str
+    headers: Mapping[str, str]
+    query_params: Sequence[tuple[str, str]]
+    body: bytes | None
+    content_type: str | None
+    host_url: str = ""
+
+    def copy(self, **kwargs: Any) -> "RequestMessage":
+        return replace(self, **kwargs)
+
+
+@dataclass
+class ResponseMessage:
+    """Representation of an upstream response for transformations."""
+
+    status_code: int
+    headers: Sequence[tuple[str, str]]
+    body: bytes | None
+    content_type: str | None
+
+    def copy(self, **kwargs: Any) -> "ResponseMessage":
+        return replace(self, **kwargs)
+
+
+@dataclass
+class _TransformationRule:
+    """Internal representation of a transformation rule."""
+
+    match: Mapping[str, Any]
+    request_steps: List[Callable[[RequestMessage], RequestMessage]]
+    response_steps: List[
+        Callable[[ResponseMessage, RequestMessage | None], ResponseMessage]
+    ]
+
+    def matches(self, message: RequestMessage) -> bool:
+        if not self.match:
+            return True
+
+        path_prefix = self.match.get("path_prefix")
+        if path_prefix and not message.gateway_path.startswith(path_prefix):
+            return False
+
+        methods = self.match.get("methods")
+        if methods and message.method.upper() not in {m.upper() for m in methods}:
+            return False
+
+        return True
+
+
+class TransformationPipeline:
+    """Pipeline that applies transformations based on configured rules."""
+
+    def __init__(self, rules: Iterable[_TransformationRule]):
+        self._rules = list(rules)
+
+    def apply_request(self, message: RequestMessage) -> RequestMessage:
+        for rule in self._matching_rules(message):
+            for step in rule.request_steps:
+                message = step(message)
+        return message
+
+    def apply_response(
+        self,
+        message: ResponseMessage,
+        *,
+        request_message: RequestMessage | None = None,
+    ) -> ResponseMessage:
+        request_message = request_message or RequestMessage(
+            method="",
+            gateway_path="",
+            upstream_path="",
+            headers={},
+            query_params=(),
+            body=None,
+            content_type=None,
+        )
+        for rule in self._matching_rules(request_message):
+            for step in rule.response_steps:
+                message = step(message, request_message)
+        return message
+
+    def _matching_rules(self, message: RequestMessage) -> Iterable[_TransformationRule]:
+        for rule in self._rules:
+            if rule.matches(message):
+                yield rule
+
+
+def build_pipeline(
+    rules: Mapping[str, Any] | str | Path,
+    *,
+    base_dir: str | Path | None = None,
+) -> TransformationPipeline:
+    """Build a :class:`TransformationPipeline` from transformation rules."""
+
+    if not rules:
+        return TransformationPipeline([])
+
+    if not isinstance(rules, Mapping):
+        rules = load_transformation_rules(rules, base_dir=base_dir)
+
+    base_dir_path = Path(base_dir or ".").resolve()
+    rule_entries: list[_TransformationRule] = []
+
+    global_rule = _build_rule(rules, base_dir_path)
+    if global_rule:
+        rule_entries.append(global_rule)
+
+    for route_rule in rules.get("routes", []) if isinstance(rules, Mapping) else []:
+        built = _build_rule(route_rule, base_dir_path)
+        if built:
+            rule_entries.append(built)
+
+    return TransformationPipeline(rule_entries)
+
+
+def _build_rule(rule_data: Mapping[str, Any], base_dir: Path) -> _TransformationRule | None:
+    match = rule_data.get("match", {}) if isinstance(rule_data, Mapping) else {}
+
+    request_section = rule_data.get("request", {}) if isinstance(rule_data, Mapping) else {}
+    response_section = rule_data.get("response", {}) if isinstance(rule_data, Mapping) else {}
+
+    request_steps: list[Callable[[RequestMessage], RequestMessage]] = []
+    response_steps: list[
+        Callable[[ResponseMessage, RequestMessage | None], ResponseMessage]
+    ] = []
+
+    if request_section:
+        headers_config = request_section.get("headers", {})
+        if headers_config:
+            request_steps.append(_build_header_step(headers_config))
+
+        for conversion in request_section.get("body", {}).get("conversions", []):
+            request_steps.append(_build_body_conversion_step(conversion, base_dir))
+
+        validation_section = request_section.get("validation", {})
+        openapi_config = validation_section.get("openapi") if isinstance(validation_section, Mapping) else None
+        if openapi_config:
+            validator = _build_openapi_validator(openapi_config, base_dir)
+            request_steps.append(_wrap_request_validator(validator))
+            response_steps.append(_wrap_response_validator(validator))
+
+    if response_section:
+        headers_config = response_section.get("headers", {})
+        if headers_config:
+            response_steps.append(_build_response_header_step(headers_config))
+
+        for conversion in response_section.get("body", {}).get("conversions", []):
+            response_steps.append(
+                _build_response_body_conversion_step(conversion, base_dir)
+            )
+
+    if not request_steps and not response_steps:
+        return None
+
+    return _TransformationRule(match=match, request_steps=request_steps, response_steps=response_steps)
+
+
+def _build_header_step(config: Mapping[str, Any]):
+    headers_to_set = {str(k): str(v) for k, v in config.get("set", {}).items()}
+    headers_to_remove = {h.lower() for h in config.get("remove", [])}
+
+    def step(message: RequestMessage) -> RequestMessage:
+        updated = dict(message.headers)
+        for key, value in headers_to_set.items():
+            updated[key] = value
+        for header in headers_to_remove:
+            keys = [k for k in updated if k.lower() == header]
+            for key in keys:
+                updated.pop(key, None)
+        return message.copy(headers=updated)
+
+    return step
+
+
+def _build_response_header_step(config: Mapping[str, Any]):
+    headers_to_set = [(str(k), str(v)) for k, v in config.get("set", {}).items()]
+    headers_to_remove = {h.lower() for h in config.get("remove", [])}
+
+    def step(
+        message: ResponseMessage, _request: RequestMessage | None = None
+    ) -> ResponseMessage:
+        updated = [(k, v) for k, v in message.headers if k.lower() not in headers_to_remove]
+        updated.extend(headers_to_set)
+        return message.copy(headers=tuple(updated))
+
+    return step
+
+
+def _build_body_conversion_step(config: Mapping[str, Any], base_dir: Path):
+    conversion_type = config.get("type", "format")
+
+    if conversion_type == "format":
+        from_format = config.get("from")
+        to_format = config.get("to")
+
+        def step(message: RequestMessage) -> RequestMessage:
+            source_format = from_format or _guess_format(message.content_type)
+            if not source_format or not to_format:
+                return message
+
+            converted, content_type = convert_between_formats(
+                message.body,
+                source_format,
+                to_format,
+            )
+            headers = dict(message.headers)
+            if content_type:
+                headers["Content-Type"] = content_type
+            return message.copy(body=converted, content_type=content_type, headers=headers)
+
+        return step
+
+    if conversion_type == "style":
+        name = config.get("name")
+
+        if name == "rest_to_graphql":
+            def step(message: RequestMessage) -> RequestMessage:
+                payload = _deserialize_body(message.body, message.content_type)
+                converted = rest_to_graphql(
+                    method=message.method,
+                    path=message.gateway_path,
+                    query_params=list(message.query_params),
+                    body=payload,
+                )
+                body = json.dumps(converted).encode("utf-8")
+                headers = dict(message.headers)
+                headers["Content-Type"] = "application/json"
+                return message.copy(body=body, content_type="application/json", headers=headers)
+
+            return step
+
+        if name == "graphql_to_rest":
+            def step(message: RequestMessage) -> RequestMessage:
+                payload = _deserialize_body(message.body, message.content_type)
+                if not isinstance(payload, Mapping):
+                    return message
+                converted = graphql_to_rest(payload)
+                body = converted.get("body")
+                if body is not None:
+                    body_bytes = json.dumps(body).encode("utf-8")
+                    headers = dict(message.headers)
+                    headers["Content-Type"] = "application/json"
+                    return message.copy(
+                        method=converted.get("method", message.method),
+                        gateway_path=converted.get("path", message.gateway_path),
+                        upstream_path=converted.get("path", message.upstream_path),
+                        query_params=tuple(converted.get("query_params", message.query_params)),
+                        body=body_bytes,
+                        content_type="application/json",
+                        headers=headers,
+                    )
+                return message
+
+            return step
+
+    return lambda message: message
+
+
+def _build_response_body_conversion_step(config: Mapping[str, Any], base_dir: Path):
+    conversion_type = config.get("type", "format")
+
+    if conversion_type == "format":
+        from_format = config.get("from")
+        to_format = config.get("to")
+
+        def step(
+            message: ResponseMessage, _request: RequestMessage | None = None
+        ) -> ResponseMessage:
+            source_format = from_format or _guess_format(message.content_type)
+            if not source_format or not to_format:
+                return message
+            converted, content_type = convert_between_formats(
+                message.body,
+                source_format,
+                to_format,
+            )
+            headers = list(message.headers)
+            headers = [
+                (k, v)
+                for k, v in headers
+                if k.lower() != "content-type"
+            ]
+            if content_type:
+                headers.append(("Content-Type", content_type))
+            return message.copy(body=converted, content_type=content_type, headers=tuple(headers))
+
+        return step
+
+    if conversion_type == "style":
+        name = config.get("name")
+
+        if name == "graphql_to_rest":
+            def step(
+                message: ResponseMessage, request: RequestMessage | None = None
+            ) -> ResponseMessage:
+                payload = _deserialize_body(message.body, message.content_type)
+                if not isinstance(payload, Mapping):
+                    return message
+                converted = graphql_to_rest(payload)
+                body_data = converted.get("body")
+                if body_data is None:
+                    return message
+                body_bytes = json.dumps(body_data).encode("utf-8")
+                headers = [
+                    (k, v)
+                    for k, v in message.headers
+                    if k.lower() != "content-type"
+                ]
+                headers.append(("Content-Type", "application/json"))
+                return message.copy(body=body_bytes, content_type="application/json", headers=tuple(headers))
+
+            return step
+
+        if name == "rest_to_graphql":
+            def step(
+                message: ResponseMessage, request: RequestMessage | None = None
+            ) -> ResponseMessage:
+                payload = _deserialize_body(message.body, message.content_type)
+                converted = rest_to_graphql(
+                    method=request.method if request else "GET",
+                    path=request.gateway_path if request else "/",
+                    query_params=list(request.query_params) if request else [],
+                    body=payload,
+                )
+                body_bytes = json.dumps(converted).encode("utf-8")
+                headers = [
+                    (k, v)
+                    for k, v in message.headers
+                    if k.lower() != "content-type"
+                ]
+                headers.append(("Content-Type", "application/json"))
+                return message.copy(body=body_bytes, content_type="application/json", headers=tuple(headers))
+
+            return step
+
+    return lambda message, _request=None: message
+
+
+def _build_openapi_validator(config: Mapping[str, Any], base_dir: Path) -> OpenAPIValidator:
+    spec_path = config.get("spec")
+    if not spec_path:
+        raise TransformationError("OpenAPI validation requires a 'spec' path")
+    resolved = Path(spec_path)
+    if not resolved.is_absolute():
+        resolved = (base_dir / resolved).resolve()
+
+    version = str(config.get("version", "3.0")).strip()
+    if version.startswith("3.1"):
+        request_validator_cls = V31RequestValidator
+        response_validator_cls = V31ResponseValidator
+    else:
+        request_validator_cls = V30RequestValidator
+        response_validator_cls = V30ResponseValidator
+
+    return OpenAPIValidator(
+        spec_path=resolved,
+        request_validator_cls=request_validator_cls,
+        response_validator_cls=response_validator_cls,
+    )
+
+
+def _wrap_request_validator(validator: OpenAPIValidator):
+    def step(message: RequestMessage) -> RequestMessage:
+        try:
+            return validator.validate_request(message)
+        except _ValidatorError as exc:
+            raise OpenAPIValidationError(str(exc)) from exc
+
+    return step
+
+
+def _wrap_response_validator(validator: OpenAPIValidator):
+    def step(
+        message: ResponseMessage, request: RequestMessage | None = None
+    ) -> ResponseMessage:
+        try:
+            return validator.validate_response(message, request)
+        except _ValidatorError as exc:
+            raise OpenAPIValidationError(str(exc)) from exc
+
+    return step
+
+
+def _guess_format(content_type: str | None) -> str | None:
+    if not content_type:
+        return None
+    content_type = content_type.lower()
+    if "json" in content_type:
+        return "json"
+    if "xml" in content_type:
+        return "xml"
+    if "csv" in content_type:
+        return "csv"
+    return None
+
+
+def _deserialize_body(body: bytes | None, content_type: str | None) -> Any:
+    if body is None:
+        return None
+
+    fmt = _guess_format(content_type)
+    if fmt == "json":
+        try:
+            return json.loads(body.decode("utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return None
+    if fmt == "xml" or fmt == "csv":
+        converted, _ = convert_between_formats(body, fmt, "json")
+        try:
+            return json.loads(converted.decode("utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return None
+
+    try:
+        return json.loads(body.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None

--- a/src/transformations/rules.py
+++ b/src/transformations/rules.py
@@ -1,0 +1,72 @@
+"""Utilities to load transformation rules from YAML or JSON."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml
+
+
+class TransformationRuleError(ValueError):
+    """Raised when transformation rules cannot be loaded."""
+
+
+def load_transformation_rules(
+    source: str | Path | Mapping[str, Any],
+    *,
+    base_dir: str | Path | None = None,
+) -> dict[str, Any]:
+    """Load transformation rules from a mapping, file path or raw string.
+
+    Args:
+        source: A mapping of rules, a path to a YAML/JSON file or a raw
+            YAML/JSON string.
+        base_dir: Optional base directory used to resolve relative paths when
+            ``source`` refers to a file path.
+
+    Returns:
+        A dictionary representing the transformation rules.
+
+    Raises:
+        TransformationRuleError: If the rules cannot be parsed or are invalid.
+    """
+
+    if isinstance(source, Mapping):
+        return dict(source)
+
+    if isinstance(source, Path):
+        path = source
+    else:
+        path_candidate = Path(str(source))
+        path = path_candidate if path_candidate.exists() else None
+
+    if path:
+        if not path.is_absolute() and base_dir:
+            path = Path(base_dir) / path
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:  # pragma: no cover - hard failure
+            raise TransformationRuleError(f"Cannot read rules file: {exc}") from exc
+    else:
+        text = str(source)
+
+    text = text.strip()
+    if not text:
+        return {}
+
+    try:
+        if text.lstrip().startswith("{"):
+            return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+
+    try:
+        data = yaml.safe_load(text) or {}
+    except yaml.YAMLError as exc:
+        raise TransformationRuleError("Invalid YAML transformation rules") from exc
+
+    if not isinstance(data, dict):
+        raise TransformationRuleError("Transformation rules must be a mapping")
+
+    return data

--- a/src/transformations/validators.py
+++ b/src/transformations/validators.py
@@ -1,0 +1,131 @@
+"""Integration helpers for OpenAPI validation."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Mapping, Sequence
+
+from openapi_core import Spec
+from openapi_core.datatypes import RequestParameters
+from openapi_core.validation.exceptions import OpenAPIError
+from werkzeug.datastructures import Headers, ImmutableMultiDict
+
+if TYPE_CHECKING:  # pragma: no cover - circular import guard
+    from .pipeline import RequestMessage, ResponseMessage
+
+
+class OpenAPIValidationError(Exception):
+    """Raised when validation against an OpenAPI schema fails."""
+
+
+class _SimpleRequest:
+    def __init__(
+        self,
+        *,
+        host_url: str,
+        path: str,
+        method: str,
+        parameters: RequestParameters,
+        content_type: str,
+        body: bytes | None,
+    ) -> None:
+        self.host_url = host_url
+        self.path = path
+        self.method = method
+        self.parameters = parameters
+        self.content_type = content_type
+        self.body = body
+
+    @property
+    def full_url_pattern(self) -> str:
+        base = self.host_url.rstrip("/")
+        if not self.path.startswith("/"):
+            return f"{base}/{self.path}"
+        return f"{base}{self.path}"
+
+
+class _SimpleResponse:
+    def __init__(
+        self,
+        *,
+        status_code: int,
+        headers: Headers,
+        content_type: str,
+        data: bytes | None,
+    ) -> None:
+        self.status_code = status_code
+        self.headers = headers
+        self.content_type = content_type
+        self.data = data
+
+
+class OpenAPIValidator:
+    """Wraps openapi-core validators for request and response validation."""
+
+    def __init__(
+        self,
+        *,
+        spec_path: Path,
+        request_validator_cls,
+        response_validator_cls,
+    ) -> None:
+        self.spec_path = Path(spec_path)
+        self.spec = Spec.from_file_path(self.spec_path)
+        self.request_validator = request_validator_cls(self.spec)
+        self.response_validator = response_validator_cls(self.spec)
+
+    def validate_request(self, message: "RequestMessage") -> "RequestMessage":
+        request = _SimpleRequest(
+            host_url=message.host_url or "http://localhost",
+            path=message.gateway_path,
+            method=message.method.lower(),
+            parameters=_build_parameters(message.headers, message.query_params),
+            content_type=(message.content_type or "application/json").lower(),
+            body=message.body,
+        )
+        try:
+            self.request_validator.validate(request)
+        except OpenAPIError as exc:  # pragma: no cover - exercised via pipeline tests
+            raise OpenAPIValidationError(str(exc)) from exc
+        return message
+
+    def validate_response(
+        self,
+        message: "ResponseMessage",
+        request_message: "RequestMessage" | None = None,
+    ) -> "ResponseMessage":
+        if request_message is None:
+            return message
+        request = _SimpleRequest(
+            host_url=request_message.host_url or "http://localhost",
+            path=request_message.gateway_path,
+            method=request_message.method.lower(),
+            parameters=_build_parameters(
+                request_message.headers, request_message.query_params
+            ),
+            content_type=(request_message.content_type or "application/json").lower(),
+            body=request_message.body,
+        )
+        response = _SimpleResponse(
+            status_code=message.status_code,
+            headers=Headers(message.headers),
+            content_type=(message.content_type or "application/json").lower(),
+            data=message.body,
+        )
+        try:
+            self.response_validator.validate(request, response)
+        except OpenAPIError as exc:  # pragma: no cover - exercised via pipeline tests
+            raise OpenAPIValidationError(str(exc)) from exc
+        return message
+
+
+def _build_parameters(
+    headers: Mapping[str, str], query_params: Sequence[tuple[str, str]]
+) -> RequestParameters:
+    header_values = Headers(list(headers.items()))
+    query_values = ImmutableMultiDict(query_params)
+    return RequestParameters(
+        header=header_values,
+        query=query_values,
+        cookie=ImmutableMultiDict(),
+        path={},
+    )

--- a/tests/data/sample_openapi.yaml
+++ b/tests/data/sample_openapi.yaml
@@ -1,0 +1,21 @@
+openapi: 3.0.0
+info:
+  title: Sample API
+  version: '1.0.0'
+paths:
+  /api/users:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - username
+              properties:
+                username:
+                  type: string
+      responses:
+        '200':
+          description: OK

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import gzip
+from unittest.mock import Mock
+
+import pytest
+
+from src.app import create_app
+
+
+@pytest.fixture
+def app(monkeypatch):
+    monkeypatch.setenv("USER_SERVICE_URL", "http://upstream")
+    monkeypatch.setenv("JWT_SECRET", "secret")
+    monkeypatch.setenv("RATE_LIMIT_AUTH", "10/minute")
+    monkeypatch.setenv("RESILIENCE_BACKOFF_FACTOR", "0")
+    monkeypatch.setenv("CACHE_DEFAULT_TTL", "60")
+    app = create_app()
+    app.config["TESTING"] = True
+    return app
+
+
+@pytest.fixture
+def client(app):
+    with app.test_client() as client:
+        yield client
+
+
+def _patch_proxy_session(monkeypatch, handler):
+    mock_session = Mock()
+    mock_session.request = handler
+    monkeypatch.setattr("src.routes.proxy._get_http_session", lambda: mock_session)
+    return mock_session
+
+
+def _build_response(body: bytes, *, status: int = 200, headers: dict[str, str] | None = None):
+    response = Mock()
+    response.status_code = status
+    response.content = body
+    response.headers = headers or {"Content-Type": "application/json"}
+    response.raw = Mock(headers={})
+    return response
+
+
+def test_cache_hit_and_miss(client, app, monkeypatch):
+    calls = []
+    responses = [
+        _build_response(b"{\"value\": 1}"),
+        _build_response(b"{\"value\": 2}"),
+    ]
+
+    def fake_request(method, url, **kwargs):
+        calls.append(url)
+        return responses[len(calls) - 1]
+
+    _patch_proxy_session(monkeypatch, fake_request)
+
+    first = client.get("/api/auth/session")
+    second = client.get("/api/auth/session")
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.data == second.data
+    assert len(calls) == 1
+
+
+def test_cache_invalidation_triggers_refresh(client, app, monkeypatch):
+    calls = []
+    payloads = [b"alpha", b"beta"]
+
+    def fake_request(method, url, **kwargs):
+        calls.append(url)
+        body = payloads[min(len(calls) - 1, len(payloads) - 1)]
+        return _build_response(body)
+
+    _patch_proxy_session(monkeypatch, fake_request)
+
+    first = client.get("/api/auth/session")
+    assert first.data == b"alpha"
+    app.extensions["response_cache"].invalidate(prefix="GET:/api/auth/session")
+    second = client.get("/api/auth/session")
+    assert second.data == b"beta"
+    assert len(calls) == 2
+
+
+def test_gzip_compression_applied(client, monkeypatch):
+    body = b"{" + (b"x" * 2048) + b"}"
+
+    def fake_request(method, url, **kwargs):
+        return _build_response(body)
+
+    _patch_proxy_session(monkeypatch, fake_request)
+
+    response = client.get("/api/auth/session", headers={"Accept-Encoding": "gzip"})
+
+    assert response.status_code == 200
+    assert response.headers.get("Content-Encoding") == "gzip"
+    decompressed = gzip.decompress(response.data)
+    assert decompressed == body

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,70 @@
+"""Tests covering observability helpers."""
+
+from __future__ import annotations
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from src import app as app_module
+from src.app import create_app
+from src.observability import tracing as tracing_module
+
+
+def _build_response(status: int = 200, body: bytes | None = None):
+    import requests
+
+    response = requests.Response()
+    response.status_code = status
+    response._content = body or b"{}"
+    response.headers["Content-Type"] = "application/json"
+    response.headers["X-Test"] = "true"
+    return response
+
+
+def test_metrics_endpoint_records_requests(monkeypatch):
+    monkeypatch.setenv("USER_SERVICE_URL", "http://upstream")
+    app = create_app()
+
+    client = app.test_client()
+    response = client.get("/health/gateway")
+    assert response.status_code == 200
+
+    metrics_response = client.get("/metrics")
+    assert metrics_response.status_code == 200
+    assert metrics_response.mimetype == "text/plain"
+    payload = metrics_response.data.decode()
+
+    assert "api_gateway_http_requests_total" in payload
+    assert '{method="GET",endpoint="/health/<service>",status="200"}' in payload
+
+
+def test_proxy_tracing_creates_spans(monkeypatch):
+    exporter = InMemorySpanExporter()
+
+    monkeypatch.setenv("USER_SERVICE_URL", "http://upstream")
+    monkeypatch.setenv("LOG_AGGREGATORS", "")
+
+    monkeypatch.setattr(app_module, "configure_tracing", lambda app: None)
+
+    app = create_app()
+
+    tracing_module._provider = None
+    tracing_module._requests_instrumented = False
+    app.config["OTEL_SPAN_EXPORTER"] = exporter
+    app.config["OTEL_USE_SIMPLE_PROCESSOR"] = True
+    app.extensions.pop("tracing_configured", None)
+
+    tracing_module.configure_tracing(app)
+    monkeypatch.setattr("src.routes.proxy.requests.request", lambda **_: _build_response())
+
+    client = app.test_client()
+    resp = client.get("/api/auth")
+    assert resp.status_code == 200
+
+    trace.get_tracer_provider().force_flush()
+    spans = exporter.get_finished_spans()
+    span_names = {span.name for span in spans}
+    assert "proxy.forward" in span_names
+    forward_span = next(span for span in spans if span.name == "proxy.forward")
+    assert forward_span.attributes.get("http.status_code") == 200
+

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,176 @@
+"""Tests for security components."""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict
+
+import jwt
+import pytest
+from flask import Flask, Request
+from werkzeug.test import EnvironBuilder
+
+from src.app import _configure_ip_filters
+from src.security.api_keys import APIKeyMiddleware, APIKeyStore
+from src.security.oauth import OIDCProvider, ProviderMetadata, TokenValidationError
+from src.security.signatures import RequestSignatureMiddleware, RequestSigner
+
+
+class DummyResponse:
+    def __init__(self, status_code: int, payload: Dict[str, Any]):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class DummySession:
+    def __init__(self, metadata: Dict[str, Any]):
+        self.metadata = metadata
+        self.calls: list[str] = []
+
+    def get(self, url: str, timeout: int):  # noqa: D401 - simple stub
+        self.calls.append(url)
+        if url.endswith("/.well-known/openid-configuration"):
+            return DummyResponse(200, self.metadata)
+        raise AssertionError(f"Unexpected URL {url}")
+
+
+def build_request(
+    method: str,
+    path: str,
+    data: bytes | str = b"",
+    headers: Dict[str, str] | None = None,
+) -> Request:
+    builder = EnvironBuilder(method=method, path=path, data=data, headers=headers or {})
+    env = builder.get_environ()
+    return Request(env)
+
+
+def test_api_key_middleware_enforces_keys():
+    app = Flask(__name__)
+    store = APIKeyStore(keys={"client": "topsecret"})
+    APIKeyMiddleware(app, store, exempt_paths=())
+
+    @app.route("/protected")
+    def protected():
+        return "ok"
+
+    client = app.test_client()
+
+    missing = client.get("/protected")
+    assert missing.status_code == 401
+
+    invalid = client.get("/protected", headers={"X-API-Key": "wrong"})
+    assert invalid.status_code == 403
+
+    valid = client.get("/protected", headers={"X-API-Key": "topsecret"})
+    assert valid.status_code == 200
+
+
+def test_oidc_provider_discovers_and_validates_hs256():
+    metadata = {
+        "issuer": "https://id.example.com",
+        "authorization_endpoint": "https://id.example.com/auth",
+        "token_endpoint": "https://id.example.com/token",
+        "jwks_uri": "https://id.example.com/jwks",
+        "id_token_signing_alg_values_supported": ["HS256"],
+    }
+    session = DummySession(metadata)
+    provider = OIDCProvider(metadata["issuer"], session=session)
+
+    discovered = provider.discover(force=True)
+    assert isinstance(discovered, ProviderMetadata)
+    assert discovered.issuer == metadata["issuer"]
+
+    now = int(time.time())
+    payload = {
+        "sub": "123",
+        "aud": "api-gateway",
+        "iss": metadata["issuer"],
+        "exp": now + 300,
+        "iat": now,
+    }
+    token = jwt.encode(payload, "shared-secret", algorithm="HS256")
+
+    validated = provider.validate_token(
+        token,
+        audience="api-gateway",
+        client_secret="shared-secret",
+    )
+    assert validated["sub"] == "123"
+
+    with pytest.raises(TokenValidationError):
+        provider.validate_token(token, audience="api-gateway", client_secret="wrong")
+
+
+def test_request_signature_middleware_validates_hmac():
+    app = Flask(__name__)
+    RequestSignatureMiddleware(
+        app,
+        {"client": "sig-secret"},
+        headers_to_include=["X-Test"],
+        exempt_paths=(),
+    )
+
+    @app.route("/signed", methods=["POST"])
+    def signed():
+        return "signed"
+
+    timestamp = str(int(time.time()))
+    outbound_request = build_request(
+        "POST",
+        "/signed",
+        data=b"payload",
+        headers={"X-Test": "value", "X-Client-Id": "client"},
+    )
+    signer = RequestSigner("sig-secret")
+    signature = signer.sign(outbound_request, timestamp=timestamp, headers=["X-Test"])
+
+    client = app.test_client()
+    ok = client.post(
+        "/signed",
+        data=b"payload",
+        headers={
+            "X-Test": "value",
+            "X-Client-Id": "client",
+            "X-Timestamp": timestamp,
+            "X-Signature": signature,
+        },
+    )
+    assert ok.status_code == 200
+
+    tampered = client.post(
+        "/signed",
+        data=b"payload",
+        headers={
+            "X-Test": "value",
+            "X-Client-Id": "client",
+            "X-Timestamp": timestamp,
+            "X-Signature": "bad",
+        },
+    )
+    assert tampered.status_code == 403
+
+
+def test_ip_filtering_blocks_blacklisted_addresses():
+    app = Flask(__name__)
+    app.config["IP_WHITELIST"] = {"127.0.0.1"}
+    app.config["IP_BLACKLIST"] = {"10.0.0.1"}
+    _configure_ip_filters(app)
+
+    @app.route("/ping")
+    def ping():
+        return "pong"
+
+    client = app.test_client()
+
+    allowed = client.get("/ping")
+    assert allowed.status_code == 200
+
+    blocked = client.get("/ping", environ_overrides={"REMOTE_ADDR": "10.0.0.1"})
+    assert blocked.status_code == 403
+
+    denied = client.get("/ping", environ_overrides={"REMOTE_ADDR": "192.168.0.20"})
+    assert denied.status_code == 403

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -1,0 +1,173 @@
+"""Tests for the configurable transformation pipeline."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.transformations import (
+    OpenAPIValidationError,
+    RequestMessage,
+    ResponseMessage,
+    build_pipeline,
+)
+
+
+def _base_request(**overrides):
+    defaults = {
+        "method": "GET",
+        "gateway_path": "/api/test",
+        "upstream_path": "api/test",
+        "headers": {},
+        "query_params": tuple(),
+        "body": None,
+        "content_type": None,
+        "host_url": "http://localhost",
+    }
+    defaults.update(overrides)
+    return RequestMessage(**defaults)
+
+
+def _base_response(**overrides):
+    defaults = {
+        "status_code": 200,
+        "headers": tuple(),
+        "body": None,
+        "content_type": None,
+    }
+    defaults.update(overrides)
+    return ResponseMessage(**defaults)
+
+
+def test_header_injection_and_removal():
+    rules = {
+        "request": {
+            "headers": {
+                "set": {"X-Injected": "value"},
+                "remove": ["X-Remove"],
+            }
+        }
+    }
+    pipeline = build_pipeline(rules)
+
+    message = _base_request(headers={"X-Remove": "deprecated"})
+    transformed = pipeline.apply_request(message)
+
+    assert transformed.headers["X-Injected"] == "value"
+    assert "X-Remove" not in transformed.headers
+
+
+def test_json_to_xml_conversion():
+    rules = {
+        "request": {
+            "body": {
+                "conversions": [
+                    {"type": "format", "from": "json", "to": "xml"},
+                ]
+            }
+        }
+    }
+    pipeline = build_pipeline(rules)
+
+    payload = {"username": "alice"}
+    message = _base_request(
+        body=json.dumps(payload).encode("utf-8"),
+        content_type="application/json",
+    )
+
+    transformed = pipeline.apply_request(message)
+
+    assert transformed.content_type == "application/xml"
+    assert transformed.body is not None
+    assert b"<username>alice</username>" in transformed.body
+
+
+def test_rest_to_graphql_and_back():
+    rules = {
+        "request": {
+            "body": {
+                "conversions": [
+                    {"type": "style", "name": "rest_to_graphql"},
+                ]
+            }
+        },
+        "response": {
+            "body": {
+                "conversions": [
+                    {"type": "style", "name": "graphql_to_rest"},
+                ]
+            }
+        },
+    }
+    pipeline = build_pipeline(rules)
+
+    request_message = _base_request(
+        method="POST",
+        gateway_path="/api/users",
+        upstream_path="api/users",
+        headers={},
+        body=json.dumps({"username": "alice"}).encode("utf-8"),
+        content_type="application/json",
+        query_params=(("verbose", "true"),),
+    )
+
+    transformed_request = pipeline.apply_request(request_message)
+    assert transformed_request.body is not None
+    graphql_payload = json.loads(transformed_request.body.decode("utf-8"))
+
+    assert graphql_payload["variables"]["method"] == "POST"
+    assert graphql_payload["variables"]["query"]["verbose"] == ["true"]
+    assert graphql_payload["variables"]["body"] == {"username": "alice"}
+
+    response_payload = {
+        "query": graphql_payload["query"],
+        "variables": {
+            "method": "POST",
+            "path": "/api/users",
+            "query": {"verbose": ["true"]},
+            "body": {"username": "alice"},
+        },
+    }
+    response_message = _base_response(
+        body=json.dumps(response_payload).encode("utf-8"),
+        content_type="application/json",
+        headers=(("Content-Type", "application/json"),),
+    )
+
+    transformed_response = pipeline.apply_response(
+        response_message, request_message=transformed_request
+    )
+
+    assert transformed_response.body is not None
+    converted_body = json.loads(transformed_response.body.decode("utf-8"))
+    assert converted_body == {"username": "alice"}
+
+
+def test_openapi_validation_errors():
+    spec_path = Path("tests/data/sample_openapi.yaml")
+    rules = {
+        "request": {
+            "validation": {
+                "openapi": {"spec": str(spec_path)}
+            }
+        }
+    }
+    pipeline = build_pipeline(rules, base_dir=Path.cwd())
+
+    invalid_request = _base_request(
+        method="POST",
+        gateway_path="/api/users",
+        upstream_path="api/users",
+        headers={"Content-Type": "application/json"},
+        content_type="application/json",
+        body=json.dumps({"email": "missing username"}).encode("utf-8"),
+    )
+
+    with pytest.raises(OpenAPIValidationError):
+        pipeline.apply_request(invalid_request)
+
+    valid_request = invalid_request.copy(
+        body=json.dumps({"username": "bob"}).encode("utf-8")
+    )
+    pipeline.apply_request(valid_request)  # should not raise


### PR DESCRIPTION
## Summary
- add a reusable caching module with in-memory and Redis backends plus single-flight coordination
- configure the Flask app with pooled HTTP sessions, response caching, and automatic compression middleware
- update the proxy route to coalesce GET requests, integrate caching, and add coverage for cache behaviour and compression
- document tuning options for timeouts, caching, and compression

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9a622526c83329406a11ff737c1f8