### PR TITLE
Add API versioning support with docs and analytics

### DIFF
--- a/docs/developer/portal.md
+++ b/docs/developer/portal.md
@@ -1,0 +1,28 @@
+# Portail développeur – Intégration
+
+Le portail développeur Meetinity fournit un espace unique pour l’onboarding des équipes produit et partenaires. Ce document décrit l’intégration du portail avec l’API Gateway, notamment l’authentification SSO et le provisioning automatisé des clés d’API.
+
+## Authentification SSO
+
+* **Fédération d’identité** : le portail s’appuie sur le fournisseur OIDC configuré via `OAUTH_PROVIDER_URL`. Lorsqu’un développeur se connecte, le portail récupère un jeton d’accès signé et inscrit l’identifiant (`sub`) dans le registre interne.
+* **Flux d’approbation** : les administrateurs valident les demandes d’accès dans le portail. Une fois approuvée, l’application cliente est associée à un ou plusieurs environnements (sandbox, production) et les audiences correspondantes sont stockées côté portail.
+* **Synchronisation gateway** : la gateway consomme les métadonnées d’issuer via l’`OIDCProvider` et valide les JWT émis par le portail. Les politiques d’accès (rôles, limites de trafic) sont ensuite appliquées au niveau des blueprints versionnés (`/v1`, `/v2`).
+
+## Provisioning des clés d’API
+
+* **Clés gérées** : le portail chiffre et stocke les clés dans HSM. Lorsqu’une clé est créée, un webhook appelle l’endpoint d’administration de l’API Gateway afin d’ajouter la clé hachée dans la variable d’environnement `API_KEYS`.
+* **Rotation automatisée** : des tâches planifiées déclenchent la rotation. Le portail régénère les clés, notifie les équipes et invalide automatiquement les clés expirées dans le registre du gateway.
+* **Traçabilité** : toutes les actions (création, rotation, révocation) sont publiées dans le topic `audit.api-gateway` et visibles dans les tableaux de bord analytics.
+
+## Cycle de vie des versions d’API
+
+* Les développeurs sélectionnent la version cible lors de la création d’une application. Les versions disponibles sont exposées par le portail à partir de l’extension `api_versions` du gateway.
+* Le portail surface les en-têtes de dépréciation (`Deprecation`, `Sunset`, `Warning`) renvoyés par la gateway et prévient les équipes lorsque la date de fin approche.
+* Les rapports générés via `AnalyticsCollector` sont importés dans le portail afin de suivre l’adoption par version, détecter les intégrations inactives et initier les migrations vers les nouvelles versions.
+
+## Bonnes pratiques d’onboarding
+
+1. Créer l’application dans le portail et associer un owner SSO.
+2. Générer les clés d’API sandbox puis effectuer un appel de test sur `/v1/api/auth/ping`.
+3. Configurer les limites de trafic et activer les alertes d’expiration de clés.
+4. Planifier une revue trimestrielle des rapports analytics afin d’anticiper les dépréciations.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,2094 @@
+openapi: 3.0.3
+info:
+  title: Meetinity API Gateway
+  version: v1
+  description: Programmatic access to Meetinity user services via the gateway.
+servers:
+- url: /
+  description: Default routing
+tags:
+- name: Authentication
+- name: Users
+paths:
+  /api/auth:
+    get:
+      operationId: v1_auth_root_get
+      summary: Authentication proxy
+      description: Forward authentication requests to the upstream user service.
+      tags:
+      - Authentication
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '429':
+          description: Rate limit exceeded.
+      x-api-version: v1
+      security: []
+    post:
+      operationId: v1_auth_root_post
+      summary: Authentication proxy
+      description: Forward authentication requests to the upstream user service.
+      tags:
+      - Authentication
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '429':
+          description: Rate limit exceeded.
+      x-api-version: v1
+      security: []
+    put:
+      operationId: v1_auth_root_put
+      summary: Authentication proxy
+      description: Forward authentication requests to the upstream user service.
+      tags:
+      - Authentication
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '429':
+          description: Rate limit exceeded.
+      x-api-version: v1
+      security: []
+    delete:
+      operationId: v1_auth_root_delete
+      summary: Authentication proxy
+      description: Forward authentication requests to the upstream user service.
+      tags:
+      - Authentication
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '429':
+          description: Rate limit exceeded.
+      x-api-version: v1
+      security: []
+    patch:
+      operationId: v1_auth_root_patch
+      summary: Authentication proxy
+      description: Forward authentication requests to the upstream user service.
+      tags:
+      - Authentication
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '429':
+          description: Rate limit exceeded.
+      x-api-version: v1
+      security: []
+    options:
+      operationId: v1_auth_root_options
+      summary: Authentication proxy
+      description: Forward authentication requests to the upstream user service.
+      tags:
+      - Authentication
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '429':
+          description: Rate limit exceeded.
+      x-api-version: v1
+      security: []
+  /api/auth/{subpath}:
+    get:
+      operationId: v1_auth_subpath_get
+      summary: Authentication proxy
+      description: Forward authentication requests to the upstream user service.
+      tags:
+      - Authentication
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '429':
+          description: Rate limit exceeded.
+      x-api-version: v1
+      security: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    post:
+      operationId: v1_auth_subpath_post
+      summary: Authentication proxy
+      description: Forward authentication requests to the upstream user service.
+      tags:
+      - Authentication
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '429':
+          description: Rate limit exceeded.
+      x-api-version: v1
+      security: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    put:
+      operationId: v1_auth_subpath_put
+      summary: Authentication proxy
+      description: Forward authentication requests to the upstream user service.
+      tags:
+      - Authentication
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '429':
+          description: Rate limit exceeded.
+      x-api-version: v1
+      security: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    delete:
+      operationId: v1_auth_subpath_delete
+      summary: Authentication proxy
+      description: Forward authentication requests to the upstream user service.
+      tags:
+      - Authentication
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '429':
+          description: Rate limit exceeded.
+      x-api-version: v1
+      security: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    patch:
+      operationId: v1_auth_subpath_patch
+      summary: Authentication proxy
+      description: Forward authentication requests to the upstream user service.
+      tags:
+      - Authentication
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '429':
+          description: Rate limit exceeded.
+      x-api-version: v1
+      security: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    options:
+      operationId: v1_auth_subpath_options
+      summary: Authentication proxy
+      description: Forward authentication requests to the upstream user service.
+      tags:
+      - Authentication
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '429':
+          description: Rate limit exceeded.
+      x-api-version: v1
+      security: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+  /v1/api/auth:
+    get:
+      operationId: v1_auth_root_get
+      summary: Authentication proxy
+      description: Forward authentication requests to the upstream user service.
+      tags:
+      - Authentication
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '429':
+          description: Rate limit exceeded.
+      x-api-version: v1
+      security: []
+    post:
+      operationId: v1_auth_root_post
+      summary: Authentication proxy
+      description: Forward authentication requests to the upstream user service.
+      tags:
+      - Authentication
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '429':
+          description: Rate limit exceeded.
+      x-api-version: v1
+      security: []
+    put:
+      operationId: v1_auth_root_put
+      summary: Authentication proxy
+      description: Forward authentication requests to the upstream user service.
+      tags:
+      - Authentication
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '429':
+          description: Rate limit exceeded.
+      x-api-version: v1
+      security: []
+    delete:
+      operationId: v1_auth_root_delete
+      summary: Authentication proxy
+      description: Forward authentication requests to the upstream user service.
+      tags:
+      - Authentication
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '429':
+          description: Rate limit exceeded.
+      x-api-version: v1
+      security: []
+    patch:
+      operationId: v1_auth_root_patch
+      summary: Authentication proxy
+      description: Forward authentication requests to the upstream user service.
+      tags:
+      - Authentication
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '429':
+          description: Rate limit exceeded.
+      x-api-version: v1
+      security: []
+    options:
+      operationId: v1_auth_root_options
+      summary: Authentication proxy
+      description: Forward authentication requests to the upstream user service.
+      tags:
+      - Authentication
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '429':
+          description: Rate limit exceeded.
+      x-api-version: v1
+      security: []
+  /v1/api/auth/{subpath}:
+    get:
+      operationId: v1_auth_subpath_get
+      summary: Authentication proxy
+      description: Forward authentication requests to the upstream user service.
+      tags:
+      - Authentication
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '429':
+          description: Rate limit exceeded.
+      x-api-version: v1
+      security: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    post:
+      operationId: v1_auth_subpath_post
+      summary: Authentication proxy
+      description: Forward authentication requests to the upstream user service.
+      tags:
+      - Authentication
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '429':
+          description: Rate limit exceeded.
+      x-api-version: v1
+      security: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    put:
+      operationId: v1_auth_subpath_put
+      summary: Authentication proxy
+      description: Forward authentication requests to the upstream user service.
+      tags:
+      - Authentication
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '429':
+          description: Rate limit exceeded.
+      x-api-version: v1
+      security: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    delete:
+      operationId: v1_auth_subpath_delete
+      summary: Authentication proxy
+      description: Forward authentication requests to the upstream user service.
+      tags:
+      - Authentication
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '429':
+          description: Rate limit exceeded.
+      x-api-version: v1
+      security: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    patch:
+      operationId: v1_auth_subpath_patch
+      summary: Authentication proxy
+      description: Forward authentication requests to the upstream user service.
+      tags:
+      - Authentication
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '429':
+          description: Rate limit exceeded.
+      x-api-version: v1
+      security: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    options:
+      operationId: v1_auth_subpath_options
+      summary: Authentication proxy
+      description: Forward authentication requests to the upstream user service.
+      tags:
+      - Authentication
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '429':
+          description: Rate limit exceeded.
+      x-api-version: v1
+      security: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+  /v2/api/auth:
+    get:
+      operationId: v2_auth_root_get
+      summary: Authentication proxy
+      description: Forward authentication requests to the upstream user service.
+      tags:
+      - Authentication
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '429':
+          description: Rate limit exceeded.
+      x-api-version: v2
+      security: []
+    post:
+      operationId: v2_auth_root_post
+      summary: Authentication proxy
+      description: Forward authentication requests to the upstream user service.
+      tags:
+      - Authentication
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '429':
+          description: Rate limit exceeded.
+      x-api-version: v2
+      security: []
+    put:
+      operationId: v2_auth_root_put
+      summary: Authentication proxy
+      description: Forward authentication requests to the upstream user service.
+      tags:
+      - Authentication
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '429':
+          description: Rate limit exceeded.
+      x-api-version: v2
+      security: []
+    delete:
+      operationId: v2_auth_root_delete
+      summary: Authentication proxy
+      description: Forward authentication requests to the upstream user service.
+      tags:
+      - Authentication
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '429':
+          description: Rate limit exceeded.
+      x-api-version: v2
+      security: []
+    patch:
+      operationId: v2_auth_root_patch
+      summary: Authentication proxy
+      description: Forward authentication requests to the upstream user service.
+      tags:
+      - Authentication
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '429':
+          description: Rate limit exceeded.
+      x-api-version: v2
+      security: []
+    options:
+      operationId: v2_auth_root_options
+      summary: Authentication proxy
+      description: Forward authentication requests to the upstream user service.
+      tags:
+      - Authentication
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '429':
+          description: Rate limit exceeded.
+      x-api-version: v2
+      security: []
+  /v2/api/auth/{subpath}:
+    get:
+      operationId: v2_auth_subpath_get
+      summary: Authentication proxy
+      description: Forward authentication requests to the upstream user service.
+      tags:
+      - Authentication
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '429':
+          description: Rate limit exceeded.
+      x-api-version: v2
+      security: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    post:
+      operationId: v2_auth_subpath_post
+      summary: Authentication proxy
+      description: Forward authentication requests to the upstream user service.
+      tags:
+      - Authentication
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '429':
+          description: Rate limit exceeded.
+      x-api-version: v2
+      security: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    put:
+      operationId: v2_auth_subpath_put
+      summary: Authentication proxy
+      description: Forward authentication requests to the upstream user service.
+      tags:
+      - Authentication
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '429':
+          description: Rate limit exceeded.
+      x-api-version: v2
+      security: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    delete:
+      operationId: v2_auth_subpath_delete
+      summary: Authentication proxy
+      description: Forward authentication requests to the upstream user service.
+      tags:
+      - Authentication
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '429':
+          description: Rate limit exceeded.
+      x-api-version: v2
+      security: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    patch:
+      operationId: v2_auth_subpath_patch
+      summary: Authentication proxy
+      description: Forward authentication requests to the upstream user service.
+      tags:
+      - Authentication
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '429':
+          description: Rate limit exceeded.
+      x-api-version: v2
+      security: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    options:
+      operationId: v2_auth_subpath_options
+      summary: Authentication proxy
+      description: Forward authentication requests to the upstream user service.
+      tags:
+      - Authentication
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '429':
+          description: Rate limit exceeded.
+      x-api-version: v2
+      security: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+  /api/users:
+    get:
+      operationId: v1_users_root_get
+      summary: User management proxy
+      description: Proxy user management operations requiring JWT authentication.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+    post:
+      operationId: v1_users_root_post
+      summary: User management proxy
+      description: Proxy user management operations requiring JWT authentication.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+    put:
+      operationId: v1_users_root_put
+      summary: User management proxy
+      description: Proxy user management operations requiring JWT authentication.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+    delete:
+      operationId: v1_users_root_delete
+      summary: User management proxy
+      description: Proxy user management operations requiring JWT authentication.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+    patch:
+      operationId: v1_users_root_patch
+      summary: User management proxy
+      description: Proxy user management operations requiring JWT authentication.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+    options:
+      operationId: v1_users_root_options
+      summary: User management proxy
+      description: Proxy user management operations requiring JWT authentication.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security: []
+  /api/users/{subpath}:
+    get:
+      operationId: v1_users_subpath_get
+      summary: User management proxy
+      description: Proxy user management operations requiring JWT authentication.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    post:
+      operationId: v1_users_subpath_post
+      summary: User management proxy
+      description: Proxy user management operations requiring JWT authentication.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    put:
+      operationId: v1_users_subpath_put
+      summary: User management proxy
+      description: Proxy user management operations requiring JWT authentication.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    delete:
+      operationId: v1_users_subpath_delete
+      summary: User management proxy
+      description: Proxy user management operations requiring JWT authentication.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    patch:
+      operationId: v1_users_subpath_patch
+      summary: User management proxy
+      description: Proxy user management operations requiring JWT authentication.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    options:
+      operationId: v1_users_subpath_options
+      summary: User management proxy
+      description: Proxy user management operations requiring JWT authentication.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+  /v1/api/users:
+    get:
+      operationId: v1_users_root_get
+      summary: User management proxy
+      description: Proxy user management operations requiring JWT authentication.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+    post:
+      operationId: v1_users_root_post
+      summary: User management proxy
+      description: Proxy user management operations requiring JWT authentication.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+    put:
+      operationId: v1_users_root_put
+      summary: User management proxy
+      description: Proxy user management operations requiring JWT authentication.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+    delete:
+      operationId: v1_users_root_delete
+      summary: User management proxy
+      description: Proxy user management operations requiring JWT authentication.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+    patch:
+      operationId: v1_users_root_patch
+      summary: User management proxy
+      description: Proxy user management operations requiring JWT authentication.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+    options:
+      operationId: v1_users_root_options
+      summary: User management proxy
+      description: Proxy user management operations requiring JWT authentication.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security: []
+  /v1/api/users/{subpath}:
+    get:
+      operationId: v1_users_subpath_get
+      summary: User management proxy
+      description: Proxy user management operations requiring JWT authentication.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    post:
+      operationId: v1_users_subpath_post
+      summary: User management proxy
+      description: Proxy user management operations requiring JWT authentication.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    put:
+      operationId: v1_users_subpath_put
+      summary: User management proxy
+      description: Proxy user management operations requiring JWT authentication.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    delete:
+      operationId: v1_users_subpath_delete
+      summary: User management proxy
+      description: Proxy user management operations requiring JWT authentication.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    patch:
+      operationId: v1_users_subpath_patch
+      summary: User management proxy
+      description: Proxy user management operations requiring JWT authentication.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    options:
+      operationId: v1_users_subpath_options
+      summary: User management proxy
+      description: Proxy user management operations requiring JWT authentication.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+  /v2/api/users:
+    get:
+      operationId: v2_users_root_get
+      summary: User management proxy
+      description: Proxy user management operations requiring JWT authentication.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v2
+      security:
+      - bearerAuth: []
+    post:
+      operationId: v2_users_root_post
+      summary: User management proxy
+      description: Proxy user management operations requiring JWT authentication.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v2
+      security:
+      - bearerAuth: []
+    put:
+      operationId: v2_users_root_put
+      summary: User management proxy
+      description: Proxy user management operations requiring JWT authentication.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v2
+      security:
+      - bearerAuth: []
+    delete:
+      operationId: v2_users_root_delete
+      summary: User management proxy
+      description: Proxy user management operations requiring JWT authentication.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v2
+      security:
+      - bearerAuth: []
+    patch:
+      operationId: v2_users_root_patch
+      summary: User management proxy
+      description: Proxy user management operations requiring JWT authentication.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v2
+      security:
+      - bearerAuth: []
+    options:
+      operationId: v2_users_root_options
+      summary: User management proxy
+      description: Proxy user management operations requiring JWT authentication.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v2
+      security: []
+  /v2/api/users/{subpath}:
+    get:
+      operationId: v2_users_subpath_get
+      summary: User management proxy
+      description: Proxy user management operations requiring JWT authentication.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v2
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    post:
+      operationId: v2_users_subpath_post
+      summary: User management proxy
+      description: Proxy user management operations requiring JWT authentication.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v2
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    put:
+      operationId: v2_users_subpath_put
+      summary: User management proxy
+      description: Proxy user management operations requiring JWT authentication.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v2
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    delete:
+      operationId: v2_users_subpath_delete
+      summary: User management proxy
+      description: Proxy user management operations requiring JWT authentication.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v2
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    patch:
+      operationId: v2_users_subpath_patch
+      summary: User management proxy
+      description: Proxy user management operations requiring JWT authentication.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v2
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    options:
+      operationId: v2_users_subpath_options
+      summary: User management proxy
+      description: Proxy user management operations requiring JWT authentication.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v2
+      security: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+  /api/profile:
+    get:
+      operationId: v1_profile_root_get
+      summary: Profile proxy
+      description: Expose profile operations for authenticated users.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+    post:
+      operationId: v1_profile_root_post
+      summary: Profile proxy
+      description: Expose profile operations for authenticated users.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+    put:
+      operationId: v1_profile_root_put
+      summary: Profile proxy
+      description: Expose profile operations for authenticated users.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+    delete:
+      operationId: v1_profile_root_delete
+      summary: Profile proxy
+      description: Expose profile operations for authenticated users.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+    patch:
+      operationId: v1_profile_root_patch
+      summary: Profile proxy
+      description: Expose profile operations for authenticated users.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+    options:
+      operationId: v1_profile_root_options
+      summary: Profile proxy
+      description: Expose profile operations for authenticated users.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security: []
+  /api/profile/{subpath}:
+    get:
+      operationId: v1_profile_subpath_get
+      summary: Profile proxy
+      description: Expose profile operations for authenticated users.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    post:
+      operationId: v1_profile_subpath_post
+      summary: Profile proxy
+      description: Expose profile operations for authenticated users.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    put:
+      operationId: v1_profile_subpath_put
+      summary: Profile proxy
+      description: Expose profile operations for authenticated users.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    delete:
+      operationId: v1_profile_subpath_delete
+      summary: Profile proxy
+      description: Expose profile operations for authenticated users.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    patch:
+      operationId: v1_profile_subpath_patch
+      summary: Profile proxy
+      description: Expose profile operations for authenticated users.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    options:
+      operationId: v1_profile_subpath_options
+      summary: Profile proxy
+      description: Expose profile operations for authenticated users.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+  /v1/api/profile:
+    get:
+      operationId: v1_profile_root_get
+      summary: Profile proxy
+      description: Expose profile operations for authenticated users.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+    post:
+      operationId: v1_profile_root_post
+      summary: Profile proxy
+      description: Expose profile operations for authenticated users.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+    put:
+      operationId: v1_profile_root_put
+      summary: Profile proxy
+      description: Expose profile operations for authenticated users.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+    delete:
+      operationId: v1_profile_root_delete
+      summary: Profile proxy
+      description: Expose profile operations for authenticated users.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+    patch:
+      operationId: v1_profile_root_patch
+      summary: Profile proxy
+      description: Expose profile operations for authenticated users.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+    options:
+      operationId: v1_profile_root_options
+      summary: Profile proxy
+      description: Expose profile operations for authenticated users.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security: []
+  /v1/api/profile/{subpath}:
+    get:
+      operationId: v1_profile_subpath_get
+      summary: Profile proxy
+      description: Expose profile operations for authenticated users.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    post:
+      operationId: v1_profile_subpath_post
+      summary: Profile proxy
+      description: Expose profile operations for authenticated users.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    put:
+      operationId: v1_profile_subpath_put
+      summary: Profile proxy
+      description: Expose profile operations for authenticated users.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    delete:
+      operationId: v1_profile_subpath_delete
+      summary: Profile proxy
+      description: Expose profile operations for authenticated users.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    patch:
+      operationId: v1_profile_subpath_patch
+      summary: Profile proxy
+      description: Expose profile operations for authenticated users.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    options:
+      operationId: v1_profile_subpath_options
+      summary: Profile proxy
+      description: Expose profile operations for authenticated users.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v1
+      security: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+  /v2/api/profile:
+    get:
+      operationId: v2_profile_root_get
+      summary: Profile proxy
+      description: Expose profile operations for authenticated users.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v2
+      security:
+      - bearerAuth: []
+    post:
+      operationId: v2_profile_root_post
+      summary: Profile proxy
+      description: Expose profile operations for authenticated users.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v2
+      security:
+      - bearerAuth: []
+    put:
+      operationId: v2_profile_root_put
+      summary: Profile proxy
+      description: Expose profile operations for authenticated users.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v2
+      security:
+      - bearerAuth: []
+    delete:
+      operationId: v2_profile_root_delete
+      summary: Profile proxy
+      description: Expose profile operations for authenticated users.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v2
+      security:
+      - bearerAuth: []
+    patch:
+      operationId: v2_profile_root_patch
+      summary: Profile proxy
+      description: Expose profile operations for authenticated users.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v2
+      security:
+      - bearerAuth: []
+    options:
+      operationId: v2_profile_root_options
+      summary: Profile proxy
+      description: Expose profile operations for authenticated users.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v2
+      security: []
+  /v2/api/profile/{subpath}:
+    get:
+      operationId: v2_profile_subpath_get
+      summary: Profile proxy
+      description: Expose profile operations for authenticated users.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v2
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    post:
+      operationId: v2_profile_subpath_post
+      summary: Profile proxy
+      description: Expose profile operations for authenticated users.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v2
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    put:
+      operationId: v2_profile_subpath_put
+      summary: Profile proxy
+      description: Expose profile operations for authenticated users.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v2
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    delete:
+      operationId: v2_profile_subpath_delete
+      summary: Profile proxy
+      description: Expose profile operations for authenticated users.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v2
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    patch:
+      operationId: v2_profile_subpath_patch
+      summary: Profile proxy
+      description: Expose profile operations for authenticated users.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v2
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+    options:
+      operationId: v2_profile_subpath_options
+      summary: Profile proxy
+      description: Expose profile operations for authenticated users.
+      tags:
+      - Users
+      responses:
+        '200':
+          description: Successful proxy response.
+        '502':
+          description: Upstream service returned an error.
+        '401':
+          description: Missing or invalid JWT.
+      x-api-version: v2
+      security: []
+      parameters:
+      - name: subpath
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Additional path segments forwarded upstream.
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT

--- a/src/management/__init__.py
+++ b/src/management/__init__.py
@@ -1,0 +1,5 @@
+"""Management tooling for the API gateway."""
+
+from .analytics import AnalyticsCollector, AnalyticsReport
+
+__all__ = ["AnalyticsCollector", "AnalyticsReport"]

--- a/src/management/analytics.py
+++ b/src/management/analytics.py
@@ -1,0 +1,124 @@
+"""Analytics collection utilities for API management."""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from threading import Lock
+from typing import Any, Dict, Iterable
+
+__all__ = ["AnalyticsCollector", "AnalyticsReport"]
+
+
+@dataclass
+class AnalyticsReport:
+    """Structured summary of request analytics."""
+
+    total_requests: int
+    per_endpoint: Dict[str, int]
+    per_method: Dict[str, int]
+    per_status_code: Dict[str, int]
+    per_version: Dict[str, int]
+    average_latency_ms: Dict[str, float]
+    api_key_usage: Dict[str, int]
+
+
+class AnalyticsCollector:
+    """Collect in-memory usage analytics for the gateway."""
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self.reset()
+
+    def reset(self) -> None:
+        with self._lock:
+            self._total_requests = 0
+            self._per_endpoint: Counter[str] = Counter()
+            self._per_method: Counter[str] = Counter()
+            self._per_status_code: Counter[str] = Counter()
+            self._per_version: Counter[str] = Counter()
+            self._api_key_usage: Counter[str] = Counter()
+            self._latency_totals: Dict[str, float] = defaultdict(float)
+            self._latency_counts: Counter[str] = Counter()
+
+    def record_request(
+        self,
+        *,
+        endpoint: str,
+        method: str,
+        status_code: int,
+        version: str | None,
+        duration: float,
+        api_key: str | None = None,
+    ) -> None:
+        """Record a request/response observation."""
+
+        with self._lock:
+            self._total_requests += 1
+            self._per_endpoint[endpoint] += 1
+            self._per_method[method.upper()] += 1
+            self._per_status_code[str(status_code)] += 1
+            if version:
+                self._per_version[version] += 1
+            if api_key:
+                self._api_key_usage[api_key] += 1
+            key = f"{method.upper()} {endpoint}"
+            self._latency_totals[key] += max(duration, 0.0)
+            self._latency_counts[key] += 1
+
+    def snapshot(self) -> AnalyticsReport:
+        with self._lock:
+            averages = {
+                key: (self._latency_totals[key] / self._latency_counts[key]) * 1000.0
+                for key in self._latency_counts
+                if self._latency_counts[key]
+            }
+            return AnalyticsReport(
+                total_requests=self._total_requests,
+                per_endpoint=dict(self._per_endpoint),
+                per_method=dict(self._per_method),
+                per_status_code=dict(self._per_status_code),
+                per_version=dict(self._per_version),
+                average_latency_ms=averages,
+                api_key_usage=dict(self._api_key_usage),
+            )
+
+    def export_report(self, fmt: str = "dict") -> AnalyticsReport | Dict[str, Any] | str:
+        """Export the current analytics snapshot in various formats."""
+
+        report = self.snapshot()
+        if fmt == "dict":
+            return report
+        if fmt == "json":
+            return {
+                "total_requests": report.total_requests,
+                "per_endpoint": report.per_endpoint,
+                "per_method": report.per_method,
+                "per_status_code": report.per_status_code,
+                "per_version": report.per_version,
+                "average_latency_ms": report.average_latency_ms,
+                "api_key_usage": report.api_key_usage,
+            }
+        if fmt == "csv":
+            rows = ["metric,value"]
+            rows.append(f"total_requests,{report.total_requests}")
+            for key, value in sorted(report.per_endpoint.items()):
+                rows.append(f"endpoint::{key},{value}")
+            for key, value in sorted(report.per_method.items()):
+                rows.append(f"method::{key},{value}")
+            for key, value in sorted(report.per_status_code.items()):
+                rows.append(f"status::{key},{value}")
+            for key, value in sorted(report.per_version.items()):
+                rows.append(f"version::{key},{value}")
+            for key, value in sorted(report.average_latency_ms.items()):
+                rows.append(f"latency::{key},{value:.3f}")
+            for key, value in sorted(report.api_key_usage.items()):
+                rows.append(f"api_key::{key},{value}")
+            return "\n".join(rows)
+        raise ValueError(f"Unsupported analytics export format: {fmt}")
+
+    def iter_usage(self) -> Iterable[tuple[str, int]]:
+        """Iterate over endpoint usage counts (primarily for testing)."""
+
+        report = self.snapshot()
+        return report.per_endpoint.items()

--- a/src/middleware/deprecation.py
+++ b/src/middleware/deprecation.py
@@ -1,0 +1,63 @@
+"""Middleware for emitting API version deprecation and sunset headers."""
+
+from __future__ import annotations
+
+from flask import Flask, g
+
+__all__ = ["register_deprecation_middleware"]
+
+
+def _select_mapping_value(mapping: dict[str, str], key: str | None) -> str | None:
+    if not mapping:
+        return None
+    if key is not None and key in mapping:
+        return mapping[key]
+    if "" in mapping:
+        return mapping[""]
+    return None
+
+
+def register_deprecation_middleware(app: Flask) -> None:
+    """Attach hooks that emit RFC 8594 compatible deprecation headers."""
+
+    @app.after_request
+    def _apply_deprecation_headers(response):
+        version = getattr(g, "api_version", app.config.get("API_DEFAULT_VERSION"))
+        explicit = getattr(g, "api_version_explicit", False)
+        deprecations: dict[str, str] = app.config.get("API_VERSION_DEPRECATIONS", {})
+        sunsets: dict[str, str] = app.config.get("API_VERSION_SUNSETS", {})
+        links: dict[str, str] = app.config.get("API_VERSION_DEPRECATION_LINKS", {})
+        warnings_map: dict[str, str] = app.config.get("API_VERSION_WARNINGS", {})
+
+        deprecation_value = _select_mapping_value(deprecations, version)
+        if deprecation_value:
+            response.headers.setdefault("Deprecation", deprecation_value)
+
+        sunset_value = _select_mapping_value(sunsets, version)
+        if sunset_value:
+            response.headers.setdefault("Sunset", sunset_value)
+
+        link_value = _select_mapping_value(links, version)
+        if link_value:
+            header_value = f"<{link_value}>; rel=\"deprecation\""
+            existing_links = response.headers.getlist("Link")
+            if header_value not in existing_links:
+                response.headers.add("Link", header_value)
+
+        warning_value = None
+        if not explicit:
+            warning_value = warnings_map.get("unversioned") or warnings_map.get("")
+        if warning_value is None and version in warnings_map:
+            warning_value = warnings_map[version]
+        if warning_value is None and deprecation_value:
+            warning_value = f'299 - "API version {version} is deprecated"'
+        if warning_value:
+            response.headers.add("Warning", warning_value)
+
+        return response
+
+    app.logger.debug(
+        "Registered deprecation middleware for API versions: default=%s supported=%s",
+        app.config.get("API_DEFAULT_VERSION"),
+        app.config.get("API_VERSIONS"),
+    )

--- a/src/routes/__init__.py
+++ b/src/routes/__init__.py
@@ -1,0 +1,30 @@
+"""Route registration helpers for the API gateway."""
+
+from __future__ import annotations
+
+from flask import Flask
+
+from .proxy import PROXY_ROUTE_DEFINITIONS, create_proxy_blueprint
+
+__all__ = ["PROXY_ROUTE_DEFINITIONS", "register_versioned_proxy_blueprints"]
+
+
+def register_versioned_proxy_blueprints(app: Flask) -> None:
+    """Register proxy blueprints for each configured API version."""
+
+    versions = tuple(app.config.get("API_VERSIONS", ("v1",)))
+    default_version = app.config.get("API_DEFAULT_VERSION", versions[0] if versions else "v1")
+    app.extensions.setdefault(
+        "api_versions",
+        {
+            "supported": versions,
+            "default": default_version,
+            "aliases": [""],
+        },
+    )
+
+    # Unversioned blueprint always maps to the default version for backwards compatibility.
+    app.register_blueprint(create_proxy_blueprint(None, default_version))
+
+    for version in versions:
+        app.register_blueprint(create_proxy_blueprint(version, default_version))

--- a/src/routes/docs.py
+++ b/src/routes/docs.py
@@ -1,0 +1,31 @@
+"""Blueprint exposing the generated OpenAPI documentation."""
+
+from __future__ import annotations
+
+from flask import Blueprint, current_app, jsonify, request
+import yaml
+
+__all__ = ["create_docs_blueprint"]
+
+
+def create_docs_blueprint() -> Blueprint:
+    """Expose the OpenAPI specification via the ``/docs`` endpoint."""
+
+    blueprint = Blueprint("docs", __name__)
+
+    @blueprint.get("/docs")
+    def serve_docs():
+        spec = current_app.extensions.get("openapi_spec")
+        if spec is None:
+            from ..utils.openapi import generate_openapi_document
+
+            spec = generate_openapi_document(current_app)
+        fmt = request.args.get("format", "yaml").lower()
+        if fmt == "json":
+            return jsonify(spec)
+        payload = yaml.safe_dump(spec, sort_keys=False)
+        response = current_app.response_class(payload, mimetype="application/yaml")
+        response.headers.setdefault("Cache-Control", "no-cache")
+        return response
+
+    return blueprint

--- a/src/utils/openapi.py
+++ b/src/utils/openapi.py
@@ -1,0 +1,165 @@
+"""Utilities for generating the OpenAPI description of the gateway."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+import yaml
+from flask import Flask
+
+from ..routes import PROXY_ROUTE_DEFINITIONS
+
+__all__ = ["generate_openapi_document"]
+
+
+def _operation_metadata(
+    app: Flask,
+    definition,
+    method: str,
+    version: str,
+    *,
+    explicit: bool,
+    include_subpath: bool,
+    context: str,
+) -> Dict[str, Any]:
+    responses: Dict[str, Any] = {
+        "200": {"description": "Successful proxy response."},
+        "502": {"description": "Upstream service returned an error."},
+    }
+    if definition.requires_jwt:
+        responses.setdefault("401", {"description": "Missing or invalid JWT."})
+    if definition.rate_limit_config:
+        responses.setdefault("429", {"description": "Rate limit exceeded."})
+
+    description = definition.description or definition.summary or ""
+    if not explicit:
+        warning = app.config.get("API_VERSION_WARNINGS", {}).get("unversioned") or app.config.get(
+            "API_VERSION_WARNINGS", {}
+        ).get("")
+        if warning:
+            description = f"{description}\n\n**Warning:** {warning}" if description else warning
+
+    operation: Dict[str, Any] = {
+        "operationId": f"{version}_{definition.name}_{context}_{method.lower()}",
+        "summary": definition.summary or definition.name.title(),
+        "description": description,
+        "tags": list(definition.tags),
+        "responses": responses,
+        "x-api-version": version,
+    }
+    if definition.requires_jwt and method.upper() not in {"OPTIONS"}:
+        operation["security"] = [{"bearerAuth": []}]
+    else:
+        operation["security"] = []
+    if include_subpath:
+        operation["parameters"] = [
+            {
+                "name": "subpath",
+                "in": "path",
+                "required": True,
+                "schema": {"type": "string"},
+                "description": "Additional path segments forwarded upstream.",
+            }
+        ]
+    return operation
+
+
+def generate_openapi_document(app: Flask) -> Dict[str, Any]:
+    """Generate and persist the OpenAPI specification for the gateway."""
+
+    versions = tuple(app.config.get("API_VERSIONS", ("v1",)))
+    default_version = app.config.get("API_DEFAULT_VERSION", versions[0] if versions else "v1")
+    deprecations = app.config.get("API_VERSION_DEPRECATIONS", {})
+
+    paths: Dict[str, Dict[str, Any]] = {}
+    for definition in PROXY_ROUTE_DEFINITIONS:
+        base_path = definition.gateway_path
+        for method in definition.methods:
+            operation = _operation_metadata(
+                app,
+                definition,
+                method,
+                default_version,
+                explicit=False,
+                include_subpath=False,
+                context="root",
+            )
+            if default_version in deprecations or "" in deprecations:
+                operation["deprecated"] = True
+            paths.setdefault(base_path, {})[method.lower()] = operation
+            sub_operation = _operation_metadata(
+                app,
+                definition,
+                method,
+                default_version,
+                explicit=False,
+                include_subpath=True,
+                context="subpath",
+            )
+            if default_version in deprecations or "" in deprecations:
+                sub_operation["deprecated"] = True
+            paths.setdefault(f"{base_path}/{{subpath}}", {})[method.lower()] = sub_operation
+
+        for version in versions:
+            prefixed = f"/{version}{base_path}"
+            for method in definition.methods:
+                op = _operation_metadata(
+                    app,
+                    definition,
+                    method,
+                    version,
+                    explicit=True,
+                    include_subpath=False,
+                    context="root",
+                )
+                if version in deprecations:
+                    op["deprecated"] = True
+                paths.setdefault(prefixed, {})[method.lower()] = op
+                sub_op = _operation_metadata(
+                    app,
+                    definition,
+                    method,
+                    version,
+                    explicit=True,
+                    include_subpath=True,
+                    context="subpath",
+                )
+                if version in deprecations:
+                    sub_op["deprecated"] = True
+                paths.setdefault(f"{prefixed}/{{subpath}}", {})[method.lower()] = sub_op
+
+    spec: Dict[str, Any] = {
+        "openapi": "3.0.3",
+        "info": {
+            "title": "Meetinity API Gateway",
+            "version": default_version,
+            "description": "Programmatic access to Meetinity user services via the gateway.",
+        },
+        "servers": [
+            {"url": "/", "description": "Default routing"},
+        ],
+        "tags": [
+            {"name": tag}
+            for tag in sorted({tag for definition in PROXY_ROUTE_DEFINITIONS for tag in definition.tags})
+        ],
+        "paths": paths,
+        "components": {
+            "securitySchemes": {
+                "bearerAuth": {
+                    "type": "http",
+                    "scheme": "bearer",
+                    "bearerFormat": "JWT",
+                }
+            }
+        },
+    }
+
+    output_path = app.config.get("OPENAPI_OUTPUT_PATH")
+    if output_path:
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, "w", encoding="utf-8") as handle:
+            yaml.safe_dump(spec, handle, sort_keys=False)
+
+    app.extensions["openapi_spec"] = spec
+    return spec

--- a/tests/test_api_management.py
+++ b/tests/test_api_management.py
@@ -1,0 +1,107 @@
+import os
+import os
+import sys
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.app import create_app  # noqa: E402
+
+
+def _configure_base_env(monkeypatch):
+    monkeypatch.setenv("USER_SERVICE_URL", "http://upstream")
+    monkeypatch.setenv("CORS_ORIGINS", "")
+    monkeypatch.setenv("JWT_SECRET", "secret")
+    monkeypatch.setenv("RATE_LIMIT_AUTH", "20/minute")
+    monkeypatch.setenv("RESILIENCE_BACKOFF_FACTOR", "0")
+
+
+def _patch_proxy(monkeypatch, status_code=200, headers=None):
+    headers = headers or {}
+    mock_resp = Mock()
+    mock_resp.status_code = status_code
+    mock_resp.content = b"{}"
+    mock_resp.headers = headers
+    mock_resp.raw = Mock(headers={})
+
+    session = Mock()
+    session.request = Mock(return_value=mock_resp)
+    monkeypatch.setattr("src.routes.proxy._get_http_session", lambda: session)
+    return mock_resp, session
+
+
+@pytest.fixture
+def app_factory(monkeypatch):
+    def _factory(extra_env=None):
+        _configure_base_env(monkeypatch)
+        if extra_env:
+            for key, value in extra_env.items():
+                monkeypatch.setenv(key, value)
+        _patch_proxy(monkeypatch)
+        app = create_app()
+        app.config["TESTING"] = True
+        return app
+
+    return _factory
+
+
+def test_versioned_routes_available(app_factory):
+    app = app_factory()
+    client = app.test_client()
+
+    for path in ("/api/auth/ping", "/v1/api/auth/ping", "/v2/api/auth/ping"):
+        response = client.get(path)
+        assert response.status_code in {200, 502}
+
+
+def test_deprecation_headers_emitted(monkeypatch, app_factory):
+    extra_env = {
+        "API_VERSION_DEPRECATIONS": "v1=true",
+        "API_VERSION_SUNSETS": "v1=2024-12-31T00:00:00Z",
+        "API_VERSION_WARNINGS": 'v1=299 - "Version v1 deprecated"',
+    }
+    app = app_factory(extra_env=extra_env)
+    client = app.test_client()
+
+    response = client.get("/v1/api/auth/ping")
+    assert response.status_code in {200, 502}
+    assert response.headers.get("Deprecation") == "true"
+    assert response.headers.get("Sunset") == "2024-12-31T00:00:00Z"
+    warning_headers = response.headers.getlist("Warning")
+    assert any("Version v1 deprecated" in header for header in warning_headers)
+
+
+def test_docs_endpoint_exports_openapi(app_factory):
+    app = app_factory()
+    client = app.test_client()
+
+    response = client.get("/docs")
+    assert response.status_code == 200
+    assert b"openapi" in response.data
+
+    json_response = client.get("/docs?format=json")
+    assert json_response.status_code == 200
+    payload = json_response.get_json()
+    assert payload["info"]["title"] == "Meetinity API Gateway"
+
+    spec_path = Path(app.config["OPENAPI_OUTPUT_PATH"])
+    assert spec_path.exists()
+
+
+def test_analytics_collector_tracks_versions(monkeypatch, app_factory):
+    app = app_factory()
+    client = app.test_client()
+
+    client.get("/api/auth/session")
+    client.get("/v2/api/users")
+
+    analytics = app.extensions["analytics"]
+    report = analytics.snapshot()
+
+    assert report.total_requests >= 2
+    assert "v1" in report.per_version
+    assert "v2" in report.per_version
+    assert any("auth" in key for key in report.per_endpoint)

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -55,6 +55,7 @@ def test_proxy_tracing_creates_spans(monkeypatch):
     monkeypatch.setattr(app_module, "configure_tracing", lambda app: None)
 
     app = create_app()
+    app.config["TESTING"] = True
 
     tracing_module._provider = None
     tracing_module._requests_instrumented = False


### PR DESCRIPTION
## Summary
- implement versioned proxy blueprints with analytics tracking and deprecation headers
- generate the OpenAPI specification automatically and serve it via a new /docs endpoint
- document developer portal integration and add API management test coverage

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9afb2bc4883329877854d67447e2f